### PR TITLE
feat: description info for experiment

### DIFF
--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -142,3 +142,33 @@ func TestModelRegistryFlow(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestExpInfo(t *testing.T) {
+	t.Run("add_description_to_exp", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange
+		expID := "exp_info_test"
+		desc := "some_new_description"
+
+		controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
+		run := types.NewRun("exp_info_run", expID)
+
+		err := controller.CreateRun(t.Context(), run)
+		require.NoError(t, err)
+
+		info, err := controller.ExpInfo(t.Context(), expID)
+		require.NoError(t, err)
+		require.Zero(t, info)
+
+		// Act
+		err = controller.SetExpInfo(t.Context(), expID, types.ExperimentInfo{
+			Description: desc,
+		})
+		require.NoError(t, err)
+
+		info, err = controller.ExpInfo(t.Context(), expID)
+		require.NoError(t, err)
+		assert.Equal(t, desc, info.Description)
+	})
+}

--- a/solid/controllers/exp.go
+++ b/solid/controllers/exp.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/zeddo123/mlsolid/solid/types"
 )
@@ -25,4 +26,26 @@ func (c *Controller) RunsFromExp(ctx context.Context, expID string) ([]*types.Ru
 
 func (c *Controller) Exps(ctx context.Context) ([]string, error) {
 	return c.Redis.Exps(ctx)
+}
+
+// ExpInfo returns info data linked to an experiment (description, etc).
+func (c *Controller) ExpInfo(ctx context.Context, expID string) (types.ExperimentInfo, error) {
+	info, err := c.Redis.ExpInfo(ctx, expID)
+	if err != nil {
+		return info, fmt.Errorf("could not pull ExpInfo: %w", err)
+	}
+
+	return info, nil
+}
+
+// SetExpInfo updates an experiment's info data.
+func (c *Controller) SetExpInfo(ctx context.Context, expID string,
+	info types.ExperimentInfo,
+) error {
+	err := c.Redis.SetExpInfo(ctx, expID, info)
+	if err != nil {
+		return fmt.Errorf("could not set ExpInfo: %w", err)
+	}
+
+	return nil
 }

--- a/solid/store/exp.go
+++ b/solid/store/exp.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/redis/go-redis/v9"
@@ -82,4 +83,33 @@ func (r *RedisStore) Exps(ctx context.Context) ([]string, error) {
 	}
 
 	return ids, nil
+}
+
+// ExpInfo pulls an experiment's info data.
+func (r *RedisStore) ExpInfo(ctx context.Context, expID string) (types.ExperimentInfo, error) {
+	key := r.makeExperimentInfoKey(expID)
+
+	m, err := r.Client.HGetAll(ctx, key).Result()
+	if err != nil {
+		return types.ExperimentInfo{}, fmt.Errorf("could not find exp info: %w", err)
+	}
+
+	return types.NewExperimentInfo(m), nil
+}
+
+// SetExpInfo sets an experiment's info data. returns non-nil error if operation was
+// not successful.
+func (r *RedisStore) SetExpInfo(ctx context.Context, expID string, info types.ExperimentInfo) error {
+	if expID == "" {
+		return errors.New("invalid expID") //nolint: err113
+	}
+
+	key := r.makeExperimentInfoKey(expID)
+
+	err := r.Client.HSet(ctx, key, info).Err()
+	if err != nil {
+		return fmt.Errorf("could not save experiment info: %w", err)
+	}
+
+	return nil
 }

--- a/solid/store/redis.go
+++ b/solid/store/redis.go
@@ -10,29 +10,41 @@ import (
 )
 
 const (
+	// ExpInfoKeyPattern is a pattern to a key that holds
+	// information on experiments.
+	ExpInfoKeyPattern = "exp:info:%s"
+
+	// ExpKeyPattern is a pattern to an experiment key
+	// that holds index of all runs linked to that exp.
 	ExpKeyPattern = "exp:%s"
+
 	// RunKeyPattern pattern of a Run's key
 	// Example:
 	// run:linear-regression
 	RunKeyPattern = "run:%s"
+
 	// MetricKeyPattern pattern of a metric metric:<metric_name>:<run_id>
 	// Example
 	// metric:mse:linear-regression
 	MetricKeyPattern = "metric:%s:%s"
+
 	// ArtifactKeyPattern pattern of a artifact's key
 	// Example
 	// artifact:logs:linear-regression
 	ArtifactKeyPattern = "artifact:%s:%s"
 
 	ModelRegistryInfoKeyPattern = "info:registry:%s"
+
 	// ModelRegistryKeyPattern pattern a model registry key
 	// Example
 	// registry:yolov12
 	ModelRegistryKeyPattern = "registry:%s"
+
 	// ModelRegistryTagsKeyPattern pattern a model registry's tags
 	// Example
 	// tag:registry:yolov12 -> [prod, latest, ...]
 	ModelRegistryTagsKeyPattern = "tag:registry:%s"
+
 	// ModelRegistryTagKeyPattern pattern a model registry tag
 	// Example
 	// tag:registry:yolov12:prod
@@ -47,6 +59,10 @@ type RedisStore struct {
 
 func (r *RedisStore) makeExpKey(id string) string {
 	return fmt.Sprintf(ExpKeyPattern, id)
+}
+
+func (r *RedisStore) makeExperimentInfoKey(expID string) string {
+	return fmt.Sprintf(ExpInfoKeyPattern, expID)
 }
 
 func (r *RedisStore) makeRunKey(name string) string {

--- a/solid/types/experiment.go
+++ b/solid/types/experiment.go
@@ -4,3 +4,16 @@ type Experiment struct {
 	Name string
 	Runs []*Run
 }
+
+// ExperimentInfo is struct that represent
+// additional (user-set) information on an experiment.
+type ExperimentInfo struct {
+	Description string `redis:"Description"`
+}
+
+// NewExperimentInfo creates an ExperimentInfo struct from the provided hasmap.
+func NewExperimentInfo(m map[string]string) ExperimentInfo {
+	return ExperimentInfo{
+		Description: m["Description"],
+	}
+}


### PR DESCRIPTION
This commit provides a way to add info data to experiments. Any new experiment data that would need to be added in the future can land inside `ExperimentInfo` struct

closes #17