### PR TITLE
feat: generate a random color in hex format

### DIFF
--- a/solid/api/v1/api_models.go
+++ b/solid/api/v1/api_models.go
@@ -1,0 +1,14 @@
+package v1
+
+// Experiment struct returned by Experiment endpoint.
+type Experiment struct {
+	Details string    `json:"details"`
+	Runs    []runInfo `json:"runs"`
+	Metrics []string  `json:"metrics"`
+}
+
+type runInfo struct {
+	RunID     string `json:"runId"`
+	Timestamp string `json:"timestamp"`
+	Color     string `json:"color"`
+}

--- a/solid/api/v1/exps.go
+++ b/solid/api/v1/exps.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/zeddo123/mlsolid/solid/types"
 )
@@ -54,11 +56,23 @@ func experiment(ctx *fiber.Ctx) error {
 		})
 	}
 
-	metrics := types.UniqueMetrics(rs)
+	runsInfo := make([]runInfo, len(rs))
 
-	return ctx.Status(fiber.StatusOK).JSON(fiber.Map{
-		"runs":    runs,
-		"metrics": metrics,
-		"details": "successfully retrieved experiment",
-	})
+	for i, r := range rs {
+		if r != nil {
+			runsInfo[i] = runInfo{
+				RunID:     r.Name,
+				Timestamp: r.Timestamp.Format(time.RFC3339),
+				Color:     r.Color,
+			}
+		}
+	}
+
+	out := Experiment{
+		Details: "successfully retrieved experiment",
+		Runs:    runsInfo,
+		Metrics: types.UniqueMetrics(rs),
+	}
+
+	return ctx.Status(fiber.StatusOK).JSON(out)
 }

--- a/solid/store/redis.go
+++ b/solid/store/redis.go
@@ -12,7 +12,7 @@ import (
 const (
 	// ExpInfoKeyPattern is a pattern to a key that holds
 	// information on experiments.
-	ExpInfoKeyPattern = "exp:info:%s"
+	ExpInfoKeyPattern = "info:exp:%s"
 
 	// ExpKeyPattern is a pattern to an experiment key
 	// that holds index of all runs linked to that exp.

--- a/solid/store/run.go
+++ b/solid/store/run.go
@@ -9,6 +9,10 @@ import (
 	"github.com/zeddo123/mlsolid/solid/types"
 )
 
+// SetRun saves a run to the redis store. Saving a run involves:
+// 1 - runKey (run:runId) is where the run data is stored
+// 2 - expKey (exp:expId) key index for all runs of an experiment
+// 3 - metrics (metric:metricName:runId) where each metric of the run is stored.
 func (r *RedisStore) SetRun(ctx context.Context, run types.Run) error {
 	key := r.makeRunKey(run.Name)
 
@@ -20,13 +24,17 @@ func (r *RedisStore) SetRun(ctx context.Context, run types.Run) error {
 
 			return nil
 		})
+		if err != nil {
+			return fmt.Errorf("could not run Tx: %w", err)
+		}
 
-		return err
+		return nil
 	}
 
 	return r.runTx(ctx, fn, TransactionMaxTries, key)
 }
 
+// RunExists checks if a run exists in the redis store.
 func (r *RedisStore) RunExists(ctx context.Context, runID string) (bool, error) {
 	key := r.makeRunKey(runID)
 
@@ -81,6 +89,7 @@ func (r *RedisStore) parseRun(ctx context.Context, hashRes *redis.MapStringStrin
 		Name:         mapping["Name"],
 		Timestamp:    timestamp,
 		ExperimentID: mapping["ExperimentID"],
+		Color:        mapping["Color"],
 		Metrics:      metrics,
 	}, nil
 }
@@ -146,6 +155,7 @@ func setRunHash(ctx context.Context, p redis.Pipeliner, key string, run types.Ru
 		"Name":         run.Name,
 		"Timestamp":    run.Timestamp.Format(time.RFC3339),
 		"ExperimentID": run.ExperimentID,
+		"Color":        run.Color,
 	})
 }
 

--- a/solid/types/run.go
+++ b/solid/types/run.go
@@ -1,30 +1,46 @@
 package types
 
 import (
+	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"maps"
+	"math/rand/v2"
 	"slices"
+	"sync"
 	"time"
 )
 
+var (
+	chacha8Source  *rand.ChaCha8 //nolint: gochecknoglobals
+	initRandSource sync.Once     //nolint: gochecknoglobals
+)
+
+// Run struct holds all data (information, metrics, artifacts) related to a run.
 type Run struct {
 	Name         string
 	Timestamp    time.Time
 	ExperimentID string
+	Color        string
 	Metrics      map[string]Metric
 	Artifacts    map[string]Artifact
 }
 
+// NewRun initializes a new run with a name and an experiment id.
+// The supplied name is normalized to avoid whitespace.
 func NewRun(name string, expID string) Run {
 	return Run{
 		Name:         normalizeName(name),
 		ExperimentID: expID,
 		Timestamp:    time.Now(),
+		Color:        generateColor(),
 		Metrics:      make(map[string]Metric),
 		Artifacts:    make(map[string]Artifact),
 	}
 }
 
+// AddMetric adds a new metric with a name.
+// returns an error if the metric name is already in use `ErrAlreadyInUse`.
 func (r *Run) AddMetric(name string, m Metric) error {
 	if r.Metrics == nil {
 		return ErrInvalidInput
@@ -40,7 +56,9 @@ func (r *Run) AddMetric(name string, m Metric) error {
 	return nil
 }
 
-func (r Run) AddAritifact(name string, a Artifact) error {
+// AddAritifact adds a new artifact to the run. Retruns a non-nil
+// error if the supplied name is already in use `ErrAlreadyInUse`.
+func (r *Run) AddAritifact(name string, a Artifact) error {
 	if r.Artifacts == nil {
 		return ErrInvalidInput
 	}
@@ -55,7 +73,7 @@ func (r Run) AddAritifact(name string, a Artifact) error {
 	return nil
 }
 
-func (r Run) ArtifactsSlice() []Artifact {
+func (r *Run) ArtifactsSlice() []Artifact {
 	if r.Artifacts == nil {
 		return []Artifact{}
 	}
@@ -69,6 +87,7 @@ func (r Run) ArtifactsSlice() []Artifact {
 	return artifacts
 }
 
+// UniqueMetrics returns all distinct/unique metric names ids from a slice of runs.
 func UniqueMetrics(runs []*Run) []string {
 	metrics := make(map[string]struct{})
 
@@ -81,6 +100,8 @@ func UniqueMetrics(runs []*Run) []string {
 	return slices.Collect(maps.Keys(metrics))
 }
 
+// CollectMetric aggregates all values of a metric present in a slice of runs.
+// Returns a key-value map of runIds (keys) and metric values.
 func CollectMetric(runs []*Run, metric string) (map[string]any, MetricType) {
 	metrics := make(map[string]any, len(runs))
 
@@ -96,4 +117,30 @@ func CollectMetric(runs []*Run, metric string) (map[string]any, MetricType) {
 	}
 
 	return metrics, kind
+}
+
+// generateColor generetes a random color in hex format `#342d13`.
+func generateColor() string {
+	initRandSource.Do(func() {
+		s := uint64(time.Now().UnixNano())
+
+		uintSize := 8
+		seed := make([]byte, uintSize)
+
+		binary.LittleEndian.PutUint64(seed, s)
+
+		var chaSeed [32]byte
+		copy(chaSeed[:], seed)
+		chacha8Source = rand.NewChaCha8(chaSeed)
+	})
+
+	size := 3
+	bytes := make([]byte, size)
+
+	_, err := chacha8Source.Read(bytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return "#" + hex.EncodeToString(bytes)
 }

--- a/solid/types/run_test.go
+++ b/solid/types/run_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zeddo123/mlsolid/solid/types"
 )
 
 func TestRun(t *testing.T) {
+	t.Parallel()
+
 	r := types.NewRun("Linear regression 1", "linreg")
 
 	m := &types.GenericMetric[float64]{
@@ -18,8 +21,18 @@ func TestRun(t *testing.T) {
 	err := r.AddMetric("mse", m)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "linear-regression-1", r.Name)
 	assert.Equal(t, r.Metrics["mse"], m)
 	assert.Equal(t, "linreg", r.ExperimentID)
+}
+
+func TestRunColorGeneration(t *testing.T) {
+	t.Parallel()
+
+	r := types.NewRun("run_name", "exp23")
+
+	t.Log(r.Color)
+	assert.NotEmpty(t, r.Color)
+	assert.Regexp(t, "^#[a-fA-F0-9]{6}", r.Color)
 }


### PR DESCRIPTION
This commit adds a new automatically generated hex color when a new run is created. This PR introduces a breaking change for the Experiment endpoint (/v1/exp/expId) so as to return said color.

closes #26 