### PR TITLE
feat: define benchmark rpc methods

### DIFF
--- a/proto/mlsolid/v1/mlsolid.proto
+++ b/proto/mlsolid/v1/mlsolid.proto
@@ -232,11 +232,10 @@ message SetBenchmarkContainerResponse {
   bool set = 1;
 }
 
-
 message BenchmarkRequest {
   string benchmark_name = 1;
 }
-message BenchmarkResponse{
+message BenchmarkResponse {
   string name = 1;
   bool eager_start = 2;
   bool auto_tag = 3;
@@ -249,7 +248,7 @@ message BenchmarkResponse{
   bool from_s3 = 10;
 }
 
-message CreateBenchmarkRequest{
+message CreateBenchmarkRequest {
   string name = 1;
   bool eager_start = 2;
   bool auto_tag = 3;
@@ -262,18 +261,18 @@ message CreateBenchmarkRequest{
   bool from_s3 = 10;
 }
 
-message CreateBenchmarkResponse{
+message CreateBenchmarkResponse {
   bool created = 1;
 }
 
-message ToggleBenchmarkRequest{
+message ToggleBenchmarkRequest {
   bool paused = 1;
 }
-message ToggleBenchmarkResponse{
+message ToggleBenchmarkResponse {
   bool paused = 1;
 }
 
-message UpdateBenchmarkRequest{
+message UpdateBenchmarkRequest {
   optional string name = 1;
   optional bool auto_tag = 2;
   optional string tag = 3;
@@ -283,7 +282,7 @@ message UpdateBenchmarkRequest{
   repeated string remove_metrics = 7;
   repeated string decision_metric = 8;
 }
-message UpdateBenchmarkResponse{
+message UpdateBenchmarkResponse {
   string name = 1;
   bool auto_tag = 2;
   string tag = 3;
@@ -292,15 +291,15 @@ message UpdateBenchmarkResponse{
   string decision_metric = 6;
 }
 
-message DeleteBenchmarkRequest{
+message DeleteBenchmarkRequest {
   string name = 1;
 }
 
-message DeleteBenchmarkResponse{
+message DeleteBenchmarkResponse {
   bool deleted = 1;
 }
 
-message BenchmarkRunsRequest{
+message BenchmarkRunsRequest {
   string benchmark_name = 1;
 }
 message BenchmarkRunsResponse {
@@ -311,16 +310,16 @@ message Metrics {
   map<string, float> metrics = 1;
 }
 
-message BestModelRequest{
+message BestModelRequest {
   string benchmark_name = 1;
   string metric = 2;
 }
 
-message BestModelResponse{
+message BestModelResponse {
   map<string, int64> best_models = 1;
 }
 
-message BenchmarksRequest{}
-message BenchmarksResponse{
+message BenchmarksRequest {}
+message BenchmarksResponse {
   repeated string benchmarks = 1;
 }

--- a/proto/mlsolid/v1/mlsolid.proto
+++ b/proto/mlsolid/v1/mlsolid.proto
@@ -47,6 +47,17 @@ service MlsolidService {
   rpc TaggedModel(TaggedModelRequest) returns (TaggedModelResponse);
   rpc StreamTaggedModel(StreamTaggedModelRequest) returns (stream StreamTaggedModelResponse);
   rpc TagModel(TagModelRequest) returns (TagModelResponse);
+  rpc SetBenchmarkContainer(SetBenchmarkContainerRequest) returns (SetBenchmarkContainerResponse);
+
+  // Benchmarks
+  rpc Benchmark(BenchmarkRequest) returns (BenchmarkResponse);
+  rpc CreateBenchmark(CreateBenchmarkRequest) returns (CreateBenchmarkResponse);
+  rpc ToggleBenchmark(ToggleBenchmarkRequest) returns (ToggleBenchmarkResponse);
+  rpc UpdateBenchmark(UpdateBenchmarkRequest) returns (UpdateBenchmarkResponse);
+  rpc DeleteBenchmark(DeleteBenchmarkRequest) returns (DeleteBenchmarkResponse);
+  rpc BenchmarkRuns(BenchmarkRunsRequest) returns (BenchmarkRunsResponse);
+  rpc BestModel(BestModelRequest) returns (BestModelResponse);
+  rpc Benchmarks(BenchmarksRequest) returns (BenchmarksResponse);
 }
 
 message Metric {
@@ -210,4 +221,106 @@ message TagModelRequest {
 
 message TagModelResponse {
   bool added = 1;
+}
+
+message SetBenchmarkContainerRequest {
+  string registry_name = 1;
+  string container_url = 2;
+}
+
+message SetBenchmarkContainerResponse {
+  bool set = 1;
+}
+
+
+message BenchmarkRequest {
+  string benchmark_name = 1;
+}
+message BenchmarkResponse{
+  string name = 1;
+  bool eager_start = 2;
+  bool auto_tag = 3;
+  string tag = 4;
+  repeated string model_registries = 5;
+  repeated string metrics = 6;
+  string decision_metric = 7;
+  string dataset_name = 8;
+  string dataset_url = 9;
+  bool from_s3 = 10;
+}
+
+message CreateBenchmarkRequest{
+  string name = 1;
+  bool eager_start = 2;
+  bool auto_tag = 3;
+  string tag = 4;
+  repeated string model_registries = 5;
+  repeated string metrics = 6;
+  string decision_metric = 7;
+  string dataset_name = 8;
+  string dataset_url = 9;
+  bool from_s3 = 10;
+}
+
+message CreateBenchmarkResponse{
+  bool created = 1;
+}
+
+message ToggleBenchmarkRequest{
+  bool paused = 1;
+}
+message ToggleBenchmarkResponse{
+  bool paused = 1;
+}
+
+message UpdateBenchmarkRequest{
+  optional string name = 1;
+  optional bool auto_tag = 2;
+  optional string tag = 3;
+  repeated string add_registires = 4;
+  repeated string remove_registries = 5;
+  repeated string add_metrics = 6;
+  repeated string remove_metrics = 7;
+  repeated string decision_metric = 8;
+}
+message UpdateBenchmarkResponse{
+  string name = 1;
+  bool auto_tag = 2;
+  string tag = 3;
+  repeated string model_registries = 4;
+  repeated string metrics = 5;
+  string decision_metric = 6;
+}
+
+message DeleteBenchmarkRequest{
+  string name = 1;
+}
+
+message DeleteBenchmarkResponse{
+  bool deleted = 1;
+}
+
+message BenchmarkRunsRequest{
+  string benchmark_name = 1;
+}
+message BenchmarkRunsResponse {
+  map<string, Metrics> runs = 1;
+}
+
+message Metrics {
+  map<string, float> metrics = 1;
+}
+
+message BestModelRequest{
+  string benchmark_name = 1;
+  string metric = 2;
+}
+
+message BestModelResponse{
+  map<string, int64> best_models = 1;
+}
+
+message BenchmarksRequest{}
+message BenchmarksResponse{
+  repeated string benchmarks = 1;
 }


### PR DESCRIPTION
This PR adds new rpc methods to allow benchmarking model registries.

A benchmark in mlsolid is characterized by:
1. `name` -- unique id
2. `eager_start` -- whether the benchmark should run on all already present models [Default to false]
3. `auto_tag` -- specifies if the benchmark should automatically apply a tag to the best performing model based on the `decision_metric`
4. `tag` -- tag to apply if `auto_tag` is enabled
5. `model_registries` -- model registries involved in the benchmark
6. `metrics` -- metrics used to compare models
7. `decision_metric` -- metric used for `auto_tag`
8. `dataset_name` -- name of dataset used in the benchmark
9. `dataset_url` -- source to dataset
10. `from_s3` -- specifies if dataset is in the same s3 used to upload artifacts and models (otherwise dataset_url is expected as public)

`Benchmark` -- Querying a benchmark
`CreateBenchmark` -- Creates a new benchmark
`TooggleBenchmark` -- Enable/Disable a benchmark
`UpdateBenchmark` -- Updates a benchmark
`DeleteBenchmark` -- Deletes a benchmark
`BenchmarkRuns` -- Returns all runs of a benchmark `BestModel` -- Returns best performing model (on a specify metric) for each model registry
`Benchmarks` -- Returns a list of benchmarks

We also introduce a `container` to registries that specifies a docker image that could be used by Benchmarks.