### PR TITLE
feat: API key store operations

### DIFF
--- a/proto/mlsolid/v1/mlsolid.proto
+++ b/proto/mlsolid/v1/mlsolid.proto
@@ -235,7 +235,6 @@ message SetBenchmarkContainerResponse {
 message BenchmarkMetric {
   string name = 1;
   bool desc_sort = 2;
-
 }
 
 message BenchmarkRequest {

--- a/solid/config.go
+++ b/solid/config.go
@@ -11,6 +11,8 @@ import (
 type Config struct {
 	Prod bool `mapstructure:"prod"`
 
+	APIKeyAccess bool `mapstructure:"api_key_access"`
+
 	APIPort  string `mapstructure:"api_port"`
 	GrpcPort string `mapstructure:"grpc_port"`
 
@@ -40,6 +42,8 @@ func LoadConfig(path string) (Config, error) {
 	viper.AddConfigPath("/etc/mlsolid/")
 
 	viper.SetDefault("prod", "true")
+
+	viper.SetDefault("api_key_access", false)
 
 	viper.SetDefault("api_port", "8050")
 	viper.SetDefault("grpc_port", "5000")

--- a/solid/store/api_key.go
+++ b/solid/store/api_key.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/zeddo123/mlsolid/solid/types"
+)
+
+const apiKeyLength = 32
+
+const apiKeyDuration = 2048 * time.Hour
+
+// IsValidAPIKey returns true if the API key is valid.
+func (r *RedisStore) IsValidAPIKey(ctx context.Context, key string) (bool, error) {
+	c, err := r.Client.Exists(ctx, r.makeAPIKey(key)).Result()
+	if err != nil {
+		return false, fmt.Errorf("failed to check if api is present: %w", err)
+	}
+
+	return c == 1, nil
+}
+
+// GenerateKey generates a new key and saves it to the store.
+func (r *RedisStore) GenerateKey(ctx context.Context) (string, error) {
+	key, err := types.NewAPIKey(apiKeyLength)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate: %w", err)
+	}
+
+	_, err = r.Client.Set(ctx, r.makeAPIKey(key), "1", apiKeyDuration).Result()
+	if err != nil {
+		return "", fmt.Errorf("could not set api key: %w", err)
+	}
+
+	return key, nil
+}

--- a/solid/store/redis.go
+++ b/solid/store/redis.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	// APIKeyPattern pattern that represents a api key
+	APIKeyPattern = "api-key:%s"
+
 	// ExpInfoKeyPattern is a pattern to a key that holds
 	// information on experiments.
 	ExpInfoKeyPattern = "info:exp:%s"
@@ -83,6 +86,10 @@ const (
 
 type RedisStore struct {
 	Client redis.Client
+}
+
+func (r *RedisStore) makeAPIKey(key string) string {
+	return fmt.Sprintf(APIKeyPattern, key)
 }
 
 func (r *RedisStore) makeExpKey(id string) string {

--- a/solid/types/api_key.go
+++ b/solid/types/api_key.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// NewAPIKey generates a new API key.
+func NewAPIKey(length int) (string, error) {
+	bytes := make([]byte, length)
+
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random key: %w", err)
+	}
+
+	return hex.EncodeToString(bytes), nil
+}


### PR DESCRIPTION
This PR adds store operations to generate and check validity of API keys. We also introduce `api_key_access` configuration var that allows enable/disable checking API keys. At first, it will default to `false` since the authentication method has not been implemented yet. When it lands, `api_key_access` should be true by default.