### PR TITLE
fix: Unbound buffer size when uploading artifacts

### DIFF
--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -74,7 +74,8 @@ func TestArtifact(t *testing.T) {
 		controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
 
 		run := types.NewRun("run_artifact", "artifact_exp")
-		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: bytes.NewReader([]byte{1, 2, 3})}
+		artifactContent := []byte{1, 2, 3}
+		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: bytes.NewReader(artifactContent)}
 
 		// Act
 		err := controller.CreateRun(context.Background(), run)
@@ -89,10 +90,12 @@ func TestArtifact(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, content)
 		assert.NotNil(t, savedArtifact)
+
 		defer content.Close()
 		b, err := io.ReadAll(content)
+
 		require.NoError(t, err)
-		assert.Equal(t, artifact.Checkpoint, b)
+		assert.Equal(t, artifactContent, b)
 		assert.Equal(t, "model_path.pt", savedArtifact.Name)
 		assert.Equal(t, types.ModelContentType, savedArtifact.ContentType)
 		assert.NotZero(t, savedArtifact.S3Key)

--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -3,6 +3,7 @@
 package controllers_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -73,7 +74,7 @@ func TestArtifact(t *testing.T) {
 		controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
 
 		run := types.NewRun("run_artifact", "artifact_exp")
-		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: []byte{1, 2, 3}}
+		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: bytes.NewReader([]byte{1, 2, 3})}
 
 		// Act
 		err := controller.CreateRun(context.Background(), run)
@@ -120,8 +121,8 @@ func TestModelRegistryFlow(t *testing.T) {
 		controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
 
 		run := types.NewRun("run2", "exp2")
-		checkpoint := make([]byte, 1024)
-		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: checkpoint}
+		checkpoint := make([]byte, 3024)
+		artifact := types.CheckpointArtifact{Model: "model_path.pt", Checkpoint: bytes.NewReader(checkpoint)}
 
 		// Act
 		err := controller.CreateRun(t.Context(), run)

--- a/solid/grpcservice/service.go
+++ b/solid/grpcservice/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"time"
 

--- a/solid/grpcservice/service.go
+++ b/solid/grpcservice/service.go
@@ -215,7 +215,7 @@ func (s *Service) Artifact(req *mlsolidv1.ArtifactRequest, stream mlsolidv1grpc.
 }
 
 func (s *Service) AddArtifact(stream mlsolidv1grpc.MlsolidService_AddArtifactServer) error { //nolint: cyclop
-	const MaxBufferSize = 2024
+	const MaxBufferSize = 4024
 
 	buf := bytes.Buffer{}
 

--- a/solid/grpcservice/service.go
+++ b/solid/grpcservice/service.go
@@ -215,6 +215,8 @@ func (s *Service) Artifact(req *mlsolidv1.ArtifactRequest, stream mlsolidv1grpc.
 }
 
 func (s *Service) AddArtifact(stream mlsolidv1grpc.MlsolidService_AddArtifactServer) error { //nolint: cyclop
+	const MaxBufferSize = 2024
+
 	buf := bytes.Buffer{}
 
 	var contentType string
@@ -222,6 +224,12 @@ func (s *Service) AddArtifact(stream mlsolidv1grpc.MlsolidService_AddArtifactSer
 	var artifactName string
 
 	var runID string
+
+	fs, err := os.CreateTemp("", "artifact_file")
+	if err != nil {
+		return status.Errorf(codes.Internal, "could not create tmp file")
+	}
+	defer os.Remove(fs.Name())
 
 	for {
 		request, err := stream.Recv()
@@ -254,10 +262,34 @@ func (s *Service) AddArtifact(stream mlsolidv1grpc.MlsolidService_AddArtifactSer
 			if err != nil {
 				return status.Errorf(codes.Internal, "could not write data chunk %v", err)
 			}
+
+			// when buffer hits max buffer size, write to tmp file
+			if buf.Len() >= MaxBufferSize {
+				_, err := fs.Write(buf.Bytes())
+				if err != nil {
+					return status.Errorf(codes.Internal, "could not write to tmp file")
+				}
+
+				buf.Reset()
+			}
 		}
 	}
 
-	artifact, err := types.NewArtifact(artifactName, contentType, buf.Bytes())
+	// Clean remaining bytes in buffer
+	_, err = fs.Write(buf.Bytes())
+	if err != nil {
+		return status.Errorf(codes.Internal, "could not write to tmp file")
+	}
+
+	buf.Reset()
+
+	// prepare file for reading (seek to start)
+	_, err = fs.Seek(0, io.SeekStart)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed reading tmp file")
+	}
+
+	artifact, err := types.NewArtifact(artifactName, contentType, fs)
 	if err != nil {
 		return ParseError(err)
 	}

--- a/solid/grpcservice/service.go
+++ b/solid/grpcservice/service.go
@@ -229,7 +229,9 @@ func (s *Service) AddArtifact(stream mlsolidv1grpc.MlsolidService_AddArtifactSer
 	if err != nil {
 		return status.Errorf(codes.Internal, "could not create tmp file")
 	}
-	defer os.Remove(fs.Name())
+
+	defer fs.Close()           //nolint: errcheck
+	defer os.Remove(fs.Name()) //nolint: errcheck
 
 	for {
 		request, err := stream.Recv()

--- a/solid/s3/s3.go
+++ b/solid/s3/s3.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -86,7 +85,7 @@ func (s Store) UploadArtifacts(ctx context.Context, as []types.Artifact) ([]type
 	for _, a := range as {
 		key := s.GenerateKey(a.Name())
 
-		_, err := s.UploadFile(ctx, key, bytes.NewReader(a.Content()))
+		_, err := s.UploadFile(ctx, key, a.Content())
 		if err != nil {
 			errs = fmt.Errorf("%w | could not upload artifact <%s> : %w", errs, a.Name(), err)
 

--- a/solid/types/artifact.go
+++ b/solid/types/artifact.go
@@ -1,5 +1,7 @@
 package types //nolint: var-naming
 
+import "io"
+
 type ContentType string
 
 const (
@@ -9,18 +11,18 @@ const (
 
 type Artifact interface {
 	Name() string
-	Content() []byte
+	Content() io.Reader
 	ContentType() ContentType
 }
 
 type PlainTextArtifact struct {
 	FileName    string
-	FileContent string
+	FileContent io.Reader
 }
 
 type CheckpointArtifact struct {
 	Model      string
-	Checkpoint []byte
+	Checkpoint io.Reader
 }
 
 type SavedArtifact struct {
@@ -29,7 +31,7 @@ type SavedArtifact struct {
 	S3Key       string
 }
 
-func NewArtifact(name string, contentType string, content []byte) (Artifact, error) {
+func NewArtifact(name string, contentType string, content io.Reader) (Artifact, error) {
 	if !IsValidContentType(contentType) {
 		return nil, NewInvalidInputErr("unknown content type for artifact")
 	}
@@ -38,7 +40,7 @@ func NewArtifact(name string, contentType string, content []byte) (Artifact, err
 	case TextContentType:
 		return PlainTextArtifact{
 			FileName:    name,
-			FileContent: string(content),
+			FileContent: content,
 		}, nil
 
 	case ModelContentType:
@@ -55,8 +57,8 @@ func (p PlainTextArtifact) Name() string {
 	return p.FileName
 }
 
-func (p PlainTextArtifact) Content() []byte {
-	return []byte(p.FileContent)
+func (p PlainTextArtifact) Content() io.Reader {
+	return p.FileContent
 }
 
 func (p PlainTextArtifact) ContentType() ContentType {
@@ -67,7 +69,7 @@ func (c CheckpointArtifact) Name() string {
 	return c.Model
 }
 
-func (c CheckpointArtifact) Content() []byte {
+func (c CheckpointArtifact) Content() io.Reader {
 	return c.Checkpoint
 }
 


### PR DESCRIPTION
This PR fixes an unbound buffer bug that would lead service to crash if artifact size is bigger than available system memory. This is dealt with by using a tmp file.

Whenever the buffer size exceeds `MaxBufferSize`, the buffer is written to the tmp file. (MaxBufferSize is set to 4024)

Profiling this new patch for 25 seconds (on the whole service using cmd/populate), results in 76.2% decrease in total memory usage from 10.5mb to 2.5mb.