### PR TITLE
feat: stress test adding artifacts

### DIFF
--- a/cmd/populate/populate_server.go
+++ b/cmd/populate/populate_server.go
@@ -20,7 +20,7 @@ func main() {
 
 	cmd := cli.Command{ //nolint: exhaustruct
 		Name:  "populate",
-		Usage: "populate a mlsolid service with test data",
+		Usage: "populates an mlsolid service with test data",
 		Flags: []cli.Flag{
 			&cli.StringFlag{ //nolint: exhaustruct
 				Name:        "url",

--- a/cmd/stress/add_artifacts.go
+++ b/cmd/stress/add_artifacts.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"buf.build/gen/go/zeddo123/mlsolid/grpc/go/mlsolid/v1/mlsolidv1grpc"
+	mlsolidv1 "buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go/mlsolid/v1"
+	"github.com/anandvarma/namegen"
+)
+
+func addArtifacts(ctx context.Context, client mlsolidv1grpc.MlsolidServiceClient, workers int, url string) {
+	var wg sync.WaitGroup
+
+	id := namegen.New().Get()
+
+	resp, err := client.CreateRun(ctx, &mlsolidv1.CreateRunRequest{
+		RunId:        id,
+		ExperimentId: "add_artifact_stress_test",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	runID := resp.GetRunId()
+
+	count := 0
+
+	for {
+		for wid := range workers {
+			wg.Go(func() {
+				addModelArtifact(ctx, client, runID, fmt.Sprintf("%d_%d", wid, count), url)
+			})
+		}
+
+		wg.Wait()
+
+		count++
+	}
+}
+
+func addModelArtifact(ctx context.Context, client mlsolidv1grpc.MlsolidServiceClient, runID, modelName, url string) {
+	log.Printf("[stress]: adding model artifact... runId=%s artifact=%s \n", runID, modelName)
+
+	resp, err := http.Get(url) //nolint: noctx, gosec
+	if err != nil {
+		panic(err)
+	}
+
+	defer resp.Body.Close() //nolint: errcheck
+
+	log.Printf("[stress] Sending model artifact... \n")
+
+	stream, err := client.AddArtifact(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	err = stream.Send(&mlsolidv1.AddArtifactRequest{Request: &mlsolidv1.AddArtifactRequest_Metadata{
+		Metadata: &mlsolidv1.MetaData{
+			Name:  modelName,
+			Type:  "content-type/model",
+			RunId: runID,
+		},
+	}})
+	if err != nil {
+		panic(err)
+	}
+
+	chunck := 1024
+	buffer := make([]byte, chunck)
+
+	log.Printf("[stress] Sending chunks artifact... \n")
+
+	for {
+		_, err := resp.Body.Read(buffer)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			log.Printf("[ERROR] [stress] could not read next chuck... \n")
+			panic(err)
+		}
+
+		err = stream.Send(&mlsolidv1.AddArtifactRequest{Request: &mlsolidv1.AddArtifactRequest_Content{
+			Content: &mlsolidv1.Content{
+				Content: buffer,
+			},
+		}})
+		if err != nil {
+			log.Printf("[ERROR] [stress] could not send next chuck... \n")
+
+			break
+		}
+	}
+
+	r, err := stream.CloseAndRecv()
+	if err != nil {
+		panic(err)
+	}
+
+	if r.GetStatus() == mlsolidv1.Status_STATUS_FAILED {
+		log.Panicf("[ERRO] [stress] could not add artifact status=FAILED\n")
+	}
+
+	log.Printf("[stress]: added model artifact runId=%s model=%s \n", runID, modelName)
+}

--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -1,0 +1,74 @@
+// Package main
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"buf.build/gen/go/zeddo123/mlsolid/grpc/go/mlsolid/v1/mlsolidv1grpc"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const DefaultWorkers = 5
+
+func main() {
+	var url string
+
+	var workers int
+
+	var client mlsolidv1grpc.MlsolidServiceClient
+
+	cmd := cli.Command{ //nolint: exhaustruct
+		Name:  "stress",
+		Usage: "stress tests an mlsolid service",
+		Flags: []cli.Flag{
+			&cli.StringFlag{ //nolint: exhaustruct
+				Name:        "url",
+				Usage:       "mlsolid grpc url",
+				Required:    true,
+				Destination: &url,
+			},
+			&cli.IntFlag{ //nolint: exhaustruct
+				Name:        "workers",
+				Usage:       "number of workers",
+				Value:       DefaultWorkers,
+				Destination: &workers,
+			},
+		},
+		Before: func(ctx context.Context, _ *cli.Command) (context.Context, error) {
+			conn, err := grpc.NewClient(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				panic(err)
+			}
+
+			client = mlsolidv1grpc.NewMlsolidServiceClient(conn)
+
+			return ctx, nil
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "artifact",
+				Usage: "stress test adding artifacts",
+				Flags: []cli.Flag{
+					&cli.StringFlag{ //nolint: exhaustruct
+						Name:  "artifact",
+						Usage: "artifact url source",
+						Value: "https://huggingface.co/Ultralytics/YOLO11/resolve/d3043e98a1ad0e2956728c13cf1e041e0fa4220f/yolo11s.pt",
+					},
+				},
+				Action: func(ctx context.Context, c *cli.Command) error {
+					addArtifacts(ctx, client, workers, c.String("artifact"))
+
+					return nil
+				},
+			},
+		},
+	}
+
+	if err := cmd.Run(context.Background(), os.Args); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
This commit adds a new cmd under `cmd/stress` used to stress test an mlsolid service with a variable number of workers using `-workers` flag.

Initially we're adding `artifact` sub command that runs multiple AddArtifact requests. In the future, we'll be able to extend this with other endpoints.

```sh
go run ./cmd/stress -workers 5 artifact --url localhost:5000
```