### PR TITLE
fix: retain model entries order when getting a registry

### DIFF
--- a/solid/api/v1/api_models.go
+++ b/solid/api/v1/api_models.go
@@ -31,6 +31,7 @@ type Registry struct {
 
 type entryInfo struct {
 	CreatedAt time.Time `json:"createdAt,format:datetime"`
+	Tags      []string  `json:"tags"`
 }
 
 // CreateBenchmarkRequest represents a request to create a new benchmark.

--- a/solid/api/v1/registries.go
+++ b/solid/api/v1/registries.go
@@ -43,6 +43,7 @@ func registry(ctx *fiber.Ctx) error {
 	for v, entry := range reg.Models {
 		infos[v+1] = entryInfo{
 			CreatedAt: entry.Timestamp,
+			Tags:      entry.Tags,
 		}
 	}
 

--- a/solid/grpcservice/service.go
+++ b/solid/grpcservice/service.go
@@ -475,7 +475,9 @@ func (s *Service) Benchmark(ctx context.Context,
 }
 
 // CreateBenchmark grpc method to create a new benchmark.
-func (s *Service) CreateBenchmark(ctx context.Context, req *mlsolidv1.CreateBenchmarkRequest) (*mlsolidv1.CreateBenchmarkResponse, error) {
+func (s *Service) CreateBenchmark(ctx context.Context,
+	req *mlsolidv1.CreateBenchmarkRequest,
+) (*mlsolidv1.CreateBenchmarkResponse, error) {
 	id, created, err := s.Controller.CreateBenchmark(ctx, types.Bench{ //nolint: exhaustruct
 		Timestamp:      time.Now(),
 		Paused:         false,

--- a/solid/store/models.go
+++ b/solid/store/models.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -73,6 +72,8 @@ func (r *RedisStore) createModelRegistry(ctx context.Context, p redis.Pipeliner,
 
 // ModelRegistry pulls a saved model registry from the store.
 func (r *RedisStore) ModelRegistry(ctx context.Context, name string) (*types.ModelRegistry, error) { //nolint: cyclop
+	name = types.SanitizeName(name)
+
 	if err := r.ModelRegistryExists(ctx, name); err != nil {
 		return nil, err
 	}
@@ -133,9 +134,11 @@ func (r *RedisStore) ModelRegistry(ctx context.Context, name string) (*types.Mod
 
 	registry := types.NewModelRegistryWithTime(info["Name"], t)
 
+	registry.Models = make([]types.ModelEntry, len(entries))
+
 	err = registry.SetBenchmarkImage(info["BenchmarkImage"])
 	if err != nil {
-		log.Println("could not set registry benchmark image container", err)
+		r.Logger.Error().Err(err).Msg("could not set registry benchmark image container")
 	}
 
 	for _, e := range entries {
@@ -146,7 +149,7 @@ func (r *RedisStore) ModelRegistry(ctx context.Context, name string) (*types.Mod
 			return nil, types.NewInternalErr(err.Error())
 		}
 
-		registry.Models = append(registry.Models, entry)
+		registry.Models[entry.Version-1] = entry
 	}
 
 	for i, cmd := range cmds {
@@ -322,7 +325,7 @@ func (r *RedisStore) updateModelRegistry(ctx context.Context, p redis.Pipeliner,
 	p.Del(ctx, entriesKey, tagsIndexKey)
 
 	for _, entry := range entries {
-		p.LPush(ctx, entriesKey, entry)
+		p.RPush(ctx, entriesKey, entry)
 	}
 
 	// Setting model tags under key "tag:registry:%s:%s" with

--- a/solid/types/model.go
+++ b/solid/types/model.go
@@ -12,6 +12,7 @@ type ModelEntry struct {
 	Tags      []string  `json:"tags"`
 	Name      string    `json:"name"`
 	Timestamp time.Time `json:"timestamp"`
+	Version   int       `json:"version"`
 }
 
 // ModelRegistry holds data related to a registry.
@@ -103,6 +104,7 @@ func (m *ModelRegistry) Add(url string, tags ...string) {
 		URL:       url,
 		Tags:      append(tags, m.VersionTag(version)),
 		Timestamp: time.Now(),
+		Version:   version,
 	}
 
 	m.pushEntry(e)


### PR DESCRIPTION
This PR fixes an issue that would update the model registry entries key in the wrong order of creation/visioning due to LPush instead of RPush. To fix this, I've change to using RPush and introduced a version field to the ModelEntry struct