### PR TITLE
feat: add `start` and `end` timestamps for benchmark runs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/zeddo123/mlsolid
 go 1.25.0
 
 require (
-	buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260511202834-13b79e685e64.1
-	buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260511202834-13b79e685e64.1
+	buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260514105251-5529e0683f44.1
+	buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260514105251-5529e0683f44.1
 	github.com/anandvarma/namegen v1.1.1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/docker/cli v29.4.3+incompatible
+	github.com/docker/cli v29.5.0+incompatible
 	github.com/docker/go-sdk/container v0.1.0-alpha015
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/gofiber/fiber/v2 v2.52.13
@@ -31,7 +31,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redis v0.35.0
 	github.com/urfave/cli/v3 v3.8.0
 	github.com/zeddo123/pubgo v0.2.0
-	google.golang.org/grpc v1.81.0
+	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.1-20260511162637-c26a7529079a.1 h
 buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.1-20260511162637-c26a7529079a.1/go.mod h1:hrt+VebiNse6L+qHOMhzLXFN7G2PUyehzWvFoQk7wDg=
 buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260511202834-13b79e685e64.1 h1:NvmjnNoTgBcIuicJkrrE1YbPOBpZyBNtOFtLStWNdmw=
 buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260511202834-13b79e685e64.1/go.mod h1:+7ylSzg61qpbtXVKsGgl2dEQtIJldaQ4exl0pAymd0U=
+buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260514105251-5529e0683f44.1 h1:D2F0gL7l/u1xpd4HQgUKkCYhWriOGyWLvfH4ldH1R5U=
+buf.build/gen/go/zeddo123/mlsolid/grpc/go v1.6.2-20260514105251-5529e0683f44.1/go.mod h1:S/XmAwYgYtwjwvAYbTthM1uLH1+LCyq4sgbOUdxl1nU=
 buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260511162637-c26a7529079a.1 h1:5oWkbYaaBtgUmsY0AcGLOZvVg0GcxBWTvbDJ2In7DU0=
 buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260511162637-c26a7529079a.1/go.mod h1:hy/1MzsXgacXUILi8otmOni91/GhX+XoQuLsf1zO6kk=
 buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260511202834-13b79e685e64.1 h1:1s9n9/qDXn1+pzw2yZtxG8iH6NEfZj7RXlUgwi8SPzk=
 buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260511202834-13b79e685e64.1/go.mod h1:hy/1MzsXgacXUILi8otmOni91/GhX+XoQuLsf1zO6kk=
+buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260514105251-5529e0683f44.1 h1:kfom+E36qX63mFkBmAwa16xw2LRRGDZW6jrnJI3gOQQ=
+buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go v1.36.11-20260514105251-5529e0683f44.1/go.mod h1:hy/1MzsXgacXUILi8otmOni91/GhX+XoQuLsf1zO6kk=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
@@ -97,6 +101,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v29.4.3+incompatible h1:u+UliYm2J/rYrIh2FqHQg32neRG8GjbvNuwQRTzGspU=
 github.com/docker/cli v29.4.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v29.5.0+incompatible h1:FPUvKJoKpeP4Njz8NrQdeUN8o247P7ndTiILtaP5/l4=
+github.com/docker/cli v29.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v28.0.1+incompatible h1:FCHjSRdXhNRFjlHMTv4jUNlIBbTeRjrWfeFuJp7jpo0=
 github.com/docker/docker v28.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
@@ -428,6 +434,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
 google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/solid/bengine/engine.go
+++ b/solid/bengine/engine.go
@@ -222,11 +222,15 @@ func (e *Engine) ConsumeEvent(ctx context.Context, cli *client.Client, event *ty
 	// Load model if not present
 	checkpointPath := filepath.Join(e.rootDest, "checkpoints", "model.pth")
 
+	start := time.Now()
+
 	result, err := e.RunContainer(ctx, event.DockerImage,
 		event.DatasetName, datasetPath, checkpointPath)
 	if err != nil {
 		return err
 	}
+
+	end := time.Now()
 
 	e.l.Info().Str("result", result).Msg("container exited successfully")
 
@@ -236,7 +240,7 @@ func (e *Engine) ConsumeEvent(ctx context.Context, cli *client.Client, event *ty
 		return nil
 	}
 
-	return e.RecordRun(ctx, event, result)
+	return e.RecordRun(ctx, event, start, end, result)
 }
 
 // PullDatasetFromS3 pulls a dataset from a S3 object.
@@ -399,7 +403,7 @@ func (e *Engine) RunContainer(ctx context.Context, image, datasetName, datasetPa
 }
 
 // RecordRun records a run into the store.
-func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, result string) error {
+func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, start, end time.Time, result string) error {
 	metrics := make(map[string]float32)
 
 	e.l.Debug().Str("result", result).Msg("unmarshalling result")
@@ -422,6 +426,8 @@ func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, result 
 		Version:   event.Version,
 		Metrics:   metrics,
 		Timestamp: time.Now(),
+		Start:     start,
+		End:       end,
 	}})
 	if err != nil {
 		return fmt.Errorf("could not record run into the store: %w", err)

--- a/solid/store/benchmark.go
+++ b/solid/store/benchmark.go
@@ -252,6 +252,8 @@ func (r *RedisStore) RecordRuns(ctx context.Context, benchID string, runs []type
 			"Registry":  run.Registry,
 			"Version":   run.Version,
 			"Timestamp": run.Timestamp,
+			"Start":     run.Start,
+			"End":       run.End,
 		})
 		// set index
 		p.SAdd(ctx, indexKey, runKey)
@@ -485,9 +487,21 @@ func (r *RedisStore) parseBenchRun(m map[string]string) (*types.BenchRun, error)
 		return nil, fmt.Errorf("could not parse run Timestamp: %w", err)
 	}
 
+	start, err := time.Parse(time.RFC3339, m["Start"])
+	if err != nil {
+		start = time.Time{}
+	}
+
+	end, err := time.Parse(time.RFC3339, m["End"])
+	if err != nil {
+		end = time.Time{}
+	}
+
 	delete(m, "Registry")
 	delete(m, "Version")
 	delete(m, "Timestamp")
+	delete(m, "Start")
+	delete(m, "End")
 
 	metrics := make(map[string]float32, len(m))
 
@@ -508,6 +522,8 @@ func (r *RedisStore) parseBenchRun(m map[string]string) (*types.BenchRun, error)
 
 	return &types.BenchRun{
 		Timestamp: timestamp,
+		Start:     start,
+		End:       end,
 		Registry:  reg,
 		Version:   v,
 		Metrics:   metrics,

--- a/solid/types/benchmark.go
+++ b/solid/types/benchmark.go
@@ -46,6 +46,8 @@ type BenchRun struct {
 	Version   int64
 	Metrics   map[string]float32
 	Timestamp time.Time
+	Start     time.Time
+	End       time.Time
 }
 
 // BenchEvent represents a benchmarking event.

--- a/solid/types/benchmark.go
+++ b/solid/types/benchmark.go
@@ -42,12 +42,12 @@ type UpdateBench struct {
 
 // BenchRun represents a benchmark run on a registry and version.
 type BenchRun struct {
-	Registry  string
-	Version   int64
-	Metrics   map[string]float32
-	Timestamp time.Time
-	Start     time.Time
-	End       time.Time
+	Registry  string             `json:"registry"`
+	Version   int64              `json:"version"`
+	Metrics   map[string]float32 `json:"metrics"`
+	Timestamp time.Time          `json:"timestamp"`
+	Start     time.Time          `json:"start"`
+	End       time.Time          `json:"end"`
 }
 
 // BenchEvent represents a benchmarking event.


### PR DESCRIPTION
This PR adds new fields to the `BenchRun` struct to allow saving start and end timestamp for each benchmark run recorded in the database.