### PR TITLE
fix: recording run with empty metrics fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ go.work.sum
 
 mlsolid.yaml
 mlsolid
+.mlsolid/

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 		sub := bus.Subscribe("bengine", pubgo.WithBufferSize(BengineBufferSize))
 
 		engine := bengine.New(sub,
-			bengine.WithRedisStore(&store),
+			bengine.WithRunRecorder(&controller),
 			bengine.WithS3(objectStore),
 			bengine.WithHostSourceVolume(config.HostSourceVolume),
 			bengine.WithRegistryCreds(config.DockerRegistryUsername, config.DockerRegistryPassword),

--- a/solid/bengine/engine.go
+++ b/solid/bengine/engine.go
@@ -22,7 +22,6 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/rs/zerolog"
 	"github.com/zeddo123/mlsolid/solid/s3"
-	"github.com/zeddo123/mlsolid/solid/store"
 	"github.com/zeddo123/mlsolid/solid/types"
 	"github.com/zeddo123/pubgo"
 )
@@ -30,9 +29,16 @@ import (
 // Opts handler function for setting engine configuration.
 type Opts func(cfg *Config)
 
+// RunRecorder records completed benchmark runs. Satisfied by
+// *controllers.Controller; kept narrow so bengine doesn't need access to
+// the rest of the controller's surface.
+type RunRecorder interface {
+	RecordRuns(ctx context.Context, benchID string, runs []types.BenchRun) error
+}
+
 // Engine is a benchmark runner with docker containers.
 type Engine struct {
-	store            *store.RedisStore
+	recorder         RunRecorder
 	sub              *pubgo.Subscription
 	s3               s3.ObjectStore
 	registryUsername string
@@ -44,7 +50,7 @@ type Engine struct {
 
 // Config struct for a bengine instance.
 type Config struct {
-	Store            *store.RedisStore
+	Recorder         RunRecorder
 	Sub              *pubgo.Subscription
 	S3               s3.ObjectStore
 	RegistryUsername string
@@ -110,11 +116,11 @@ func WithS3(store s3.ObjectStore) Opts {
 	}
 }
 
-// WithRedisStore sets the redis store used to record benchmarking runs.
-// If no redis store is provided, saving is skipped.
-func WithRedisStore(store *store.RedisStore) Opts {
+// WithRunRecorder sets the recorder used to save benchmarking runs.
+// If none is provided, saving is skipped.
+func WithRunRecorder(recorder RunRecorder) Opts {
 	return func(cfg *Config) {
-		cfg.Store = store
+		cfg.Recorder = recorder
 	}
 }
 
@@ -138,7 +144,7 @@ func New(sub *pubgo.Subscription, opts ...Opts) *Engine {
 		Timestamp().Logger()
 
 	return &Engine{
-		store:            cfg.Store,
+		recorder:         cfg.Recorder,
 		sub:              sub,
 		s3:               cfg.S3,
 		registryUsername: cfg.RegistryUsername,
@@ -234,8 +240,8 @@ func (e *Engine) ConsumeEvent(ctx context.Context, cli *client.Client, event *ty
 
 	e.l.Info().Str("result", result).Msg("container exited successfully")
 
-	if e.store == nil {
-		e.l.Info().Str("result", result).Msg("Redis store not configured skipping")
+	if e.recorder == nil {
+		e.l.Info().Str("result", result).Msg("run recorder not configured, skipping")
 
 		return nil
 	}
@@ -421,7 +427,7 @@ func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, start, 
 		Int("Version", int(event.Version)).
 		Msg("recording bench run into the store")
 
-	err = e.store.RecordRuns(ctx, event.BenchID, []types.BenchRun{{
+	err = e.recorder.RecordRuns(ctx, event.BenchID, []types.BenchRun{{
 		Registry:  event.Registry,
 		Version:   event.Version,
 		Metrics:   metrics,

--- a/solid/bengine/engine.go
+++ b/solid/bengine/engine.go
@@ -41,6 +41,7 @@ type Engine struct {
 	recorder         RunRecorder
 	sub              *pubgo.Subscription
 	s3               s3.ObjectStore
+	cli              *client.Client
 	registryUsername string
 	registryPassword string
 	rootDest         string
@@ -143,7 +144,7 @@ func New(sub *pubgo.Subscription, opts ...Opts) *Engine {
 		Str("component", "bENGINE").
 		Timestamp().Logger()
 
-	return &Engine{
+	return &Engine{ //nolint: exhaustruct
 		recorder:         cfg.Recorder,
 		sub:              sub,
 		s3:               cfg.S3,
@@ -157,8 +158,7 @@ func New(sub *pubgo.Subscription, opts ...Opts) *Engine {
 
 // Start starts the engine instance.
 func (e *Engine) Start(ctx context.Context) {
-	cli, err := client.New(client.FromEnv)
-	if err != nil {
+	if _, err := e.dockerClient(); err != nil {
 		e.l.Error().Err(err).Msg("could not setup docker client")
 
 		return
@@ -191,7 +191,7 @@ func (e *Engine) Start(ctx context.Context) {
 				Str("tag", event.Tag).
 				Msg("received benchmark event")
 
-			err := e.ConsumeEvent(ctx, cli, event)
+			err := e.ConsumeEvent(ctx, event)
 			if err != nil {
 				e.l.Error().Err(err).Msg("could not run benchmark")
 			}
@@ -203,8 +203,8 @@ func (e *Engine) Start(ctx context.Context) {
 }
 
 // ConsumeEvent handles a benchmarking event.
-func (e *Engine) ConsumeEvent(ctx context.Context, cli *client.Client, event *types.BenchEvent) error {
-	err := e.pullImage(ctx, cli, event.DockerImage)
+func (e *Engine) ConsumeEvent(ctx context.Context, event *types.BenchEvent) error {
+	err := e.pullImage(ctx, event.DockerImage)
 	if err != nil {
 		e.l.Error().Err(err).Msg("could not pull docker image")
 
@@ -298,15 +298,23 @@ func (e *Engine) PullDataset(ctx context.Context, url string, outputPath string,
 }
 
 // RunContainer runs a benchmark on a container with a specified image, dataset, and checkpoint.
-func (e *Engine) RunContainer(ctx context.Context, image, datasetName, datasetPath, checkpointPath string,
+func (e *Engine) RunContainer(
+	ctx context.Context, image, datasetName, datasetPath, checkpointPath string,
 ) (string, error) {
 	outputPath := "/run/output.json"
 
-	gpuOpts := opts.GpuOpts{}
+	var deviceRequests []container.DeviceRequest
 
-	err := gpuOpts.Set("all")
-	if err != nil {
-		return "", errors.New("could not set GpuOpts")
+	if e.hasGPUSupport(ctx) {
+		gpuOpts := opts.GpuOpts{}
+
+		if err := gpuOpts.Set("all"); err != nil {
+			return "", errors.New("could not set GpuOpts")
+		}
+
+		deviceRequests = gpuOpts.Value()
+	} else {
+		e.l.Warn().Msg("no GPU device driver detected on docker host, running container without GPU")
 	}
 
 	e.l.Info().
@@ -336,7 +344,7 @@ func (e *Engine) RunContainer(ctx context.Context, image, datasetName, datasetPa
 				{Type: mount.TypeBind, Source: source, Target: target, ReadOnly: true}, //nolint: exhaustruct
 			}
 			hostConfig.Resources = container.Resources{ //nolint: exhaustruct
-				DeviceRequests: gpuOpts.Value(),
+				DeviceRequests: deviceRequests,
 			}
 		}),
 	)
@@ -442,7 +450,49 @@ func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, start, 
 	return nil
 }
 
-func (e *Engine) pullImage(ctx context.Context, cli *client.Client, image string) error {
+// dockerClient returns the engine's docker client, lazily creating it on
+// first use so callers never need to pass one around explicitly.
+func (e *Engine) dockerClient() (*client.Client, error) {
+	if e.cli != nil {
+		return e.cli, nil
+	}
+
+	cli, err := client.New(client.FromEnv)
+	if err != nil {
+		return nil, fmt.Errorf("could not setup docker client: %w", err)
+	}
+
+	e.cli = cli
+
+	return e.cli, nil
+}
+
+// hasGPUSupport reports whether the docker daemon has a GPU device driver
+// (e.g. the NVIDIA container toolkit) registered. When it doesn't, requesting
+// GPU device capabilities fails the container with:
+// "could not select device driver "" with capabilities: [[gpu]]".
+func (e *Engine) hasGPUSupport(ctx context.Context) bool {
+	cli, err := e.dockerClient()
+	if err != nil {
+		return false
+	}
+
+	info, err := cli.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return false
+	}
+
+	_, ok := info.Info.Runtimes["nvidia"]
+
+	return ok
+}
+
+func (e *Engine) pullImage(ctx context.Context, image string) error {
+	cli, err := e.dockerClient()
+	if err != nil {
+		return err
+	}
+
 	opts := client.ImagePullOptions{} //nolint: exhaustruct
 
 	if e.registryUsername != "" {
@@ -457,7 +507,7 @@ func (e *Engine) pullImage(ctx context.Context, cli *client.Client, image string
 		}
 	}
 
-	_, err := cli.ImagePull(ctx, image, opts)
+	_, err = cli.ImagePull(ctx, image, opts)
 	if err != nil {
 		return fmt.Errorf("could not pull image: %w", err)
 	}

--- a/solid/bengine/engine_test.go
+++ b/solid/bengine/engine_test.go
@@ -3,18 +3,33 @@
 package bengine_test
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zeddo123/mlsolid/solid/bengine"
+	"github.com/zeddo123/mlsolid/solid/controllers"
+	"github.com/zeddo123/mlsolid/solid/store"
 	"github.com/zeddo123/mlsolid/solid/types"
 	"github.com/zeddo123/pubgo"
 )
 
-const DatasetURL = "https://www.kaggle.com/api/v1/datasets/download/gpreda/chinese-mnist"
+const (
+	DatasetURL = "https://www.kaggle.com/api/v1/datasets/download/gpreda/chinese-mnist"
+
+	// DummyImage's entrypoint always writes a fixed set of metrics to its output file,
+	// see bench-container-example/entrypoint.py.
+	DummyImage = "ghcr.io/zeddo123/bench-dummy:0.0.4"
+
+	expectedMAE  = 92.0
+	expectedLoss = 0.0023
+)
 
 func TestEngineRun(t *testing.T) {
 	t.Parallel()
@@ -26,10 +41,23 @@ func TestEngineRun(t *testing.T) {
 
 	sub := bus.Subscribe(topic)
 
+	controller := &controllers.Controller{Redis: store.RedisStore{Client: *client}} //nolint: exhaustruct
+
+	benchID, _, err := controller.CreateBenchmark(t.Context(), types.Bench{ //nolint: exhaustruct
+		Name:        "engine-run-bench",
+		Registries:  []string{"dummy-registry"},
+		Metrics:     []types.BenchMetric{{Name: "mae"}, {Name: "loss"}},
+		DatasetName: "chinese-mnist",
+		DatasetURL:  DatasetURL,
+		Timestamp:   time.Now(),
+	})
+	require.NoError(t, err)
+
 	e := bengine.New(sub,
 		bengine.WithRootDest("./.mlsolid/"),
 		bengine.WithHumanReadableLogs(),
-		bengine.WithLoggingLevel(zerolog.DebugLevel))
+		bengine.WithLoggingLevel(zerolog.DebugLevel),
+		bengine.WithRunRecorder(controller))
 
 	wg.Go(func() {
 		e.Start(t.Context())
@@ -37,15 +65,58 @@ func TestEngineRun(t *testing.T) {
 
 	require.NotNil(t, e)
 
-	err := bus.Publish(topic, &types.BenchEvent{ //nolint: exhaustruct
-		DockerImage: "ghcr.io/zeddo123/bench-dummy:0.0.4",
+	event := &types.BenchEvent{ //nolint: exhaustruct
+		BenchID:     benchID,
+		Registry:    "dummy-registry",
+		Version:     1,
+		DockerImage: DummyImage,
 		DatasetName: "chinese-mnist",
 		DatasetURL:  DatasetURL,
-	})
+	}
+
+	err = bus.Publish(topic, event)
 	require.NoError(t, err)
 
 	sub.Done()
 	wg.Wait()
+
+	runs, err := controller.BenchmarkRuns(t.Context(), event.BenchID)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+
+	metrics := runs[0].Metrics
+	assert.InDelta(t, expectedMAE, metrics["mae"], 1e-3)
+	assert.InDelta(t, expectedLoss, metrics["loss"], 1e-4)
+	assert.Equal(t, event.Registry, runs[0].Registry)
+	assert.Equal(t, event.Version, runs[0].Version)
+}
+
+// TestRunContainerExtractsFixedMetrics drives RunContainer directly (bypassing
+// pubsub/redis) to check that metrics reported by the dummy benchmark image
+// are extracted correctly from its output file.
+func TestRunContainerExtractsFixedMetrics(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	datasetPath := filepath.Join(root, "datasets", "dummy-dataset")
+	require.NoError(t, os.MkdirAll(datasetPath, 0o755))
+
+	engine := bengine.New(nil,
+		bengine.WithRootDest(root),
+		bengine.WithHumanReadableLogs(),
+		bengine.WithLoggingLevel(zerolog.DebugLevel))
+
+	result, err := engine.RunContainer(t.Context(), DummyImage, "dummy-dataset",
+		datasetPath, filepath.Join(root, "checkpoints", "model.pth"))
+	require.NoError(t, err)
+
+	var metrics map[string]float32
+
+	require.NoError(t, json.Unmarshal([]byte(result), &metrics))
+
+	assert.InDelta(t, expectedMAE, metrics["mae"], 1e-3)
+	assert.InDelta(t, expectedLoss, metrics["loss"], 1e-4)
 }
 
 func TestPullDataset(t *testing.T) {

--- a/solid/bengine/main_test.go
+++ b/solid/bengine/main_test.go
@@ -1,0 +1,53 @@
+//go:build integrationtests
+
+package bengine_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	redisv9 "github.com/redis/go-redis/v9"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/redis"
+)
+
+var client *redisv9.Client //nolint: gochecknoglobals
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	redisContainer, err := redis.Run(ctx,
+		"redis:latest",
+		redis.WithLogLevel(redis.LogLevelVerbose),
+	)
+	if err != nil {
+		log.Printf("failed to start container: %s\n", err)
+		panic(err)
+	}
+
+	conn, err := redisContainer.ConnectionString(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	opts, err := redisv9.ParseURL(conn)
+	if err != nil {
+		panic(err)
+	}
+
+	client = redisv9.NewClient(opts)
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+
+	if err := testcontainers.TerminateContainer(redisContainer); err != nil {
+		log.Printf("failed to terminate container: %s\n", err)
+	}
+
+	os.Exit(code)
+}

--- a/solid/controllers/benchmarks.go
+++ b/solid/controllers/benchmarks.go
@@ -101,6 +101,26 @@ func (c *Controller) BenchmarkRuns(ctx context.Context, benchID string) ([]*type
 	return runs, nil
 }
 
+// RecordRuns records new benchmark runs. All metrics reported by a run are
+// stored as-is, including ones not (yet) declared on the benchmark, so a run
+// already carries a value once a matching metric is added to the benchmark.
+func (c *Controller) RecordRuns(ctx context.Context, benchID string, runs []types.BenchRun) error {
+	exists, err := c.Redis.BenchmarkExists(ctx, benchID)
+	if err != nil {
+		return fmt.Errorf("%w: checking if benchmark is present failed: %w", types.ErrInternal, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("%w: benchmark does not exist", types.ErrNotFound)
+	}
+
+	if err := c.Redis.RecordRuns(ctx, benchID, runs); err != nil {
+		return fmt.Errorf("%w: could not record benchmark runs: %w", types.ErrInternal, err)
+	}
+
+	return nil
+}
+
 // Benchmarks pulls all known benchmark names.
 func (c *Controller) Benchmarks(ctx context.Context) ([]string, error) {
 	benchs, err := c.Redis.Benchmarks(ctx)

--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,6 +166,179 @@ func TestModelRegistryFlow(t *testing.T) {
 		assert.Equal(t, 1, registry.LastModel().Version)
 		assert.Equal(t, true, registry.BenchmarkGpuPassthrough)
 		assert.Equal(t, dockerImage, registry.BenchmarkImage)
+	})
+}
+
+// findRun returns the run matching registry+version from a slice pulled from the store.
+func findRun(runs []*types.BenchRun, registry string, version int64) *types.BenchRun {
+	for _, r := range runs {
+		if r.Registry == registry && r.Version == version {
+			return r
+		}
+	}
+
+	return nil
+}
+
+func TestRecordRuns(t *testing.T) {
+	t.Parallel()
+
+	controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
+
+	bench := types.Bench{ //nolint: exhaustruct
+		Name:        "record-runs-bench",
+		Registries:  []string{"dummy-registry", "shadow-registry"},
+		Metrics:     []types.BenchMetric{{Name: "mae"}, {Name: "loss"}},
+		DatasetName: "dummy-dataset",
+		DatasetURL:  "https://example.com/dataset.zip",
+		Timestamp:   time.Now(),
+	}
+
+	benchID, created, err := controller.CreateBenchmark(t.Context(), bench)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	t.Run("multiple_runs_across_registries_and_versions_are_all_recorded", func(t *testing.T) {
+		runs := []types.BenchRun{
+			{
+				Registry: "dummy-registry", Version: 1,
+				Metrics:   map[string]float32{"mae": 92.0, "loss": 0.0023},
+				Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+			},
+			{
+				Registry: "dummy-registry", Version: 2,
+				Metrics:   map[string]float32{"mae": 88.5, "loss": 0.0011},
+				Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+			},
+			{
+				Registry: "shadow-registry", Version: 1,
+				Metrics:   map[string]float32{"mae": 100.2, "loss": 0.05},
+				Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+			},
+		}
+
+		err := controller.RecordRuns(t.Context(), benchID, runs)
+		require.NoError(t, err)
+
+		got, err := controller.BenchmarkRuns(t.Context(), benchID)
+		require.NoError(t, err)
+
+		for _, want := range runs {
+			run := findRun(got, want.Registry, want.Version)
+			require.NotNilf(t, run, "missing run %s:%d", want.Registry, want.Version)
+			assert.InDeltaf(t, want.Metrics["mae"], run.Metrics["mae"], 1e-3, "%s:%d mae", want.Registry, want.Version)
+			assert.InDeltaf(t, want.Metrics["loss"], run.Metrics["loss"], 1e-4, "%s:%d loss", want.Registry, want.Version)
+		}
+	})
+
+	t.Run("metrics_not_declared_on_the_benchmark_are_still_recorded", func(t *testing.T) {
+		// RecordRuns accepts whatever metrics a run reports, even ones not
+		// (yet) part of the benchmark's declared Metrics list ("mae", "loss"
+		// here). That way a run already carries a value once a matching
+		// metric is later added to the benchmark.
+		const registry, version = "undeclared-metric-registry", 1
+
+		err := controller.RecordRuns(t.Context(), benchID, []types.BenchRun{{
+			Registry:  registry,
+			Version:   version,
+			Metrics:   map[string]float32{"gpu_mem_gb": 14.2},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.NoError(t, err)
+
+		got, err := controller.BenchmarkRuns(t.Context(), benchID)
+		require.NoError(t, err)
+
+		run := findRun(got, registry, version)
+		require.NotNil(t, run)
+		assert.InDelta(t, 14.2, run.Metrics["gpu_mem_gb"], 1e-6)
+	})
+
+	t.Run("recording_runs_for_an_unknown_benchmark_returns_not_found", func(t *testing.T) {
+		err := controller.RecordRuns(t.Context(), "unknown-benchmark-id", []types.BenchRun{{
+			Registry:  "dummy-registry",
+			Version:   1,
+			Metrics:   map[string]float32{"mae": 1},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, types.ErrNotFound))
+	})
+
+	t.Run("re-recording_same_registry_and_version_replaces_previous_metrics", func(t *testing.T) {
+		// Special case: RecordRuns clears any previous run sharing the same
+		// registry+version before writing, so a metric dropped between two
+		// runs of the same version disappears instead of leaving a stale value.
+		const registry, version = "merge-registry", 1
+
+		err := controller.RecordRuns(t.Context(), benchID, []types.BenchRun{{
+			Registry:  registry,
+			Version:   version,
+			Metrics:   map[string]float32{"mae": 10, "loss": 20, "extra": 30},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.NoError(t, err)
+
+		err = controller.RecordRuns(t.Context(), benchID, []types.BenchRun{{
+			Registry:  registry,
+			Version:   version,
+			Metrics:   map[string]float32{"mae": 99},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.NoError(t, err)
+
+		got, err := controller.BenchmarkRuns(t.Context(), benchID)
+		require.NoError(t, err)
+
+		run := findRun(got, registry, version)
+		require.NotNil(t, run)
+
+		assert.InDelta(t, 99, run.Metrics["mae"], 1e-6)
+		// fields from the first write no longer leak into the second.
+		assert.NotContains(t, run.Metrics, "loss")
+		assert.NotContains(t, run.Metrics, "extra")
+	})
+
+	t.Run("metric_names_are_sanitized", func(t *testing.T) {
+		const registry, version = "sanitize-registry", 1
+
+		err := controller.RecordRuns(t.Context(), benchID, []types.BenchRun{{
+			Registry:  registry,
+			Version:   version,
+			Metrics:   map[string]float32{"  Mean Absolute Error ": 1.23},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.NoError(t, err)
+
+		got, err := controller.BenchmarkRuns(t.Context(), benchID)
+		require.NoError(t, err)
+
+		run := findRun(got, registry, version)
+		require.NotNil(t, run)
+		assert.InDelta(t, 1.23, run.Metrics["mean-absolute-error"], 1e-6)
+	})
+
+	t.Run("run_with_no_metrics_is_recorded_without_error", func(t *testing.T) {
+		// Special case: an empty Metrics map used to turn into an HSET with
+		// zero field/value pairs, which Redis rejects. RecordRuns now skips
+		// the metrics HSET entirely when there are none, so the run is
+		// still recorded (with an empty metric set) and no error is returned.
+		const registry, version = "empty-metrics-registry", 1
+
+		err := controller.RecordRuns(t.Context(), benchID, []types.BenchRun{{
+			Registry:  registry,
+			Version:   version,
+			Metrics:   map[string]float32{},
+			Timestamp: time.Now(), Start: time.Now(), End: time.Now(),
+		}})
+		require.NoError(t, err)
+
+		got, err := controller.BenchmarkRuns(t.Context(), benchID)
+		require.NoError(t, err)
+
+		run := findRun(got, registry, version)
+		require.NotNilf(t, run, "run metadata should be recorded even with no metrics")
+		assert.Empty(t, run.Metrics)
 	})
 }
 

--- a/solid/store/benchmark.go
+++ b/solid/store/benchmark.go
@@ -247,7 +247,11 @@ func (r *RedisStore) RecordRuns(ctx context.Context, benchID string, runs []type
 	for _, run := range runs {
 		runKey := r.makeBenchmarkRunKey(benchID, run.Registry, run.Version)
 
-		p.HSet(ctx, runKey, run.SanitizedMetrics())
+		// Clear any previously recorded run so re-recording the same
+		// registry+version replaces its metrics instead of merging with
+		// stale fields left over from an earlier run.
+		p.Del(ctx, runKey)
+
 		p.HSet(ctx, runKey, map[string]any{
 			"Registry":  run.Registry,
 			"Version":   run.Version,
@@ -255,6 +259,18 @@ func (r *RedisStore) RecordRuns(ctx context.Context, benchID string, runs []type
 			"Start":     run.Start,
 			"End":       run.End,
 		})
+
+		metrics := make(map[string]any, len(run.Metrics))
+		for k, metric := range run.SanitizedMetrics() {
+			metrics[k] = metric
+		}
+
+		// Redis rejects a HSET with zero field/value pairs, so skip it
+		// entirely for a run with no metrics rather than erroring out.
+		if len(metrics) > 0 {
+			p.HSet(ctx, runKey, metrics)
+		}
+
 		// set index
 		p.SAdd(ctx, indexKey, runKey)
 	}


### PR DESCRIPTION
Passing an empty map to `redis.HSET` causes an error which partially fails RecordRuns operation.