### PR TITLE
feat: query active benchmark runs

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 	if config.EnableBEngine {
 		sub := bus.Subscribe("bengine", pubgo.WithBufferSize(BengineBufferSize))
 
-		engine := bengine.New(sub,
+		engine := bengine.New(
+			sub,
 			bengine.WithRunRecorder(&controller),
 			bengine.WithS3(objectStore),
 			bengine.WithHostSourceVolume(config.HostSourceVolume),

--- a/openapi-spec.yaml
+++ b/openapi-spec.yaml
@@ -1218,6 +1218,14 @@ components:
           format: date-time
           description: Creation or last update timestamp
           example: "2025-05-08T12:34:56Z"
+        activeBenchRun:
+          allOf:
+            - $ref: '#/components/schemas/BenchRun'
+          description: >-
+            The benchmark run currently in progress, if any. Zero-valued
+            (all fields empty/zero) when no run is active. Distinct from the
+            runs returned by the runs endpoint, which only lists completed
+            runs.
       required:
         - id
         - name

--- a/solid/bengine/engine.go
+++ b/solid/bengine/engine.go
@@ -34,6 +34,8 @@ type Opts func(cfg *Config)
 // the rest of the controller's surface.
 type RunRecorder interface {
 	RecordRuns(ctx context.Context, benchID string, runs []types.BenchRun) error
+	SetActiveBenchRun(ctx context.Context, benchID string, run types.BenchRun) error
+	RemActiveBenchRun(ctx context.Context, benchID string) error
 }
 
 // Engine is a benchmark runner with docker containers.
@@ -191,10 +193,7 @@ func (e *Engine) Start(ctx context.Context) {
 				Str("tag", event.Tag).
 				Msg("received benchmark event")
 
-			err := e.ConsumeEvent(ctx, event)
-			if err != nil {
-				e.l.Error().Err(err).Msg("could not run benchmark")
-			}
+			e.handleEvent(ctx, event)
 
 		case <-ctx.Done():
 			e.l.Info().Msg("shutting down bEngine")
@@ -448,6 +447,73 @@ func (e *Engine) RecordRun(ctx context.Context, event *types.BenchEvent, start, 
 	}
 
 	return nil
+}
+
+// activeBenchRunRetries and activeBenchRunRetryBackoff bound how hard
+// handleEvent tries to keep the recorder's active run marker in sync before
+// giving up and just logging. They guard against short-lived store hiccups
+// (e.g. a transient Redis connection blip); a sustained outage still leaves
+// the marker stuck, which activeBenchRunTTL (see store.RedisStore) bounds.
+const (
+	activeBenchRunRetries      = 3
+	activeBenchRunRetryBackoff = 2 * time.Second
+)
+
+// handleEvent runs a single benchmark event, keeping the recorder's active
+// run marker in sync around it. Cleanup runs in a defer, scoped to this call,
+// so the active run marker is cleared even if ConsumeEvent panics.
+func (e *Engine) handleEvent(ctx context.Context, event *types.BenchEvent) {
+	if e.recorder != nil {
+		run := types.BenchRun{ //nolint: exhaustruct
+			Registry: event.Registry,
+			Version:  event.Version,
+			Start:    time.Now(),
+		}
+
+		err := retryWithBackoff(ctx, activeBenchRunRetries, activeBenchRunRetryBackoff, func() error {
+			return e.recorder.SetActiveBenchRun(ctx, event.BenchID, run)
+		})
+		if err != nil {
+			e.l.Error().Err(err).Msg("could not set active benchmark run")
+		} else {
+			defer func() {
+				err := retryWithBackoff(ctx, activeBenchRunRetries, activeBenchRunRetryBackoff, func() error {
+					return e.recorder.RemActiveBenchRun(ctx, event.BenchID)
+				})
+				if err != nil {
+					e.l.Error().Err(err).Msg("could not remove active benchmark run")
+				}
+			}()
+		}
+	}
+
+	if err := e.ConsumeEvent(ctx, event); err != nil {
+		e.l.Error().Err(err).Msg("could not run benchmark")
+	}
+}
+
+// retryWithBackoff calls fn until it succeeds or attempts are exhausted,
+// waiting backoff between tries. It returns early if ctx is done.
+func retryWithBackoff(ctx context.Context, attempts int, backoff time.Duration, fn func() error) error {
+	var err error
+
+	for i := range attempts {
+		if err = fn(); err == nil {
+			return nil
+		}
+
+		if i == attempts-1 {
+			break
+		}
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return err
+		}
+	}
+
+	return err
 }
 
 // dockerClient returns the engine's docker client, lazily creating it on

--- a/solid/controllers/benchmarks.go
+++ b/solid/controllers/benchmarks.go
@@ -121,7 +121,11 @@ func (c *Controller) RecordRuns(ctx context.Context, benchID string, runs []type
 	return nil
 }
 
-// SetActiveBenchRun marks a benchmark run as the currently running one.
+// SetActiveBenchRun marks run as the one currently executing for benchID, so
+// that Benchmark's ActiveBenchRun field reflects it before the run finishes
+// and is persisted via RecordRuns. Setting a new active run replaces any
+// previous one. Callers should follow up with RemActiveBenchRun once the
+// run completes, whether it succeeded or failed.
 func (c *Controller) SetActiveBenchRun(ctx context.Context, benchID string, run types.BenchRun) error {
 	exists, err := c.Redis.BenchmarkExists(ctx, benchID)
 	if err != nil {
@@ -139,7 +143,9 @@ func (c *Controller) SetActiveBenchRun(ctx context.Context, benchID string, run 
 	return nil
 }
 
-// RemActiveBenchRun clears the currently running benchmark run, if any.
+// RemActiveBenchRun clears the run marked as currently executing for
+// benchID by SetActiveBenchRun. It succeeds without error when no run is
+// active, so it is safe to call unconditionally once a run finishes.
 func (c *Controller) RemActiveBenchRun(ctx context.Context, benchID string) error {
 	exists, err := c.Redis.BenchmarkExists(ctx, benchID)
 	if err != nil {

--- a/solid/controllers/benchmarks.go
+++ b/solid/controllers/benchmarks.go
@@ -121,6 +121,42 @@ func (c *Controller) RecordRuns(ctx context.Context, benchID string, runs []type
 	return nil
 }
 
+// SetActiveBenchRun marks a benchmark run as the currently running one.
+func (c *Controller) SetActiveBenchRun(ctx context.Context, benchID string, run types.BenchRun) error {
+	exists, err := c.Redis.BenchmarkExists(ctx, benchID)
+	if err != nil {
+		return fmt.Errorf("%w: checking if benchmark is present failed: %w", types.ErrInternal, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("%w: benchmark does not exist", types.ErrNotFound)
+	}
+
+	if err := c.Redis.SetActiveBenchRun(ctx, benchID, run); err != nil {
+		return fmt.Errorf("%w: could not set active benchmark run: %w", types.ErrInternal, err)
+	}
+
+	return nil
+}
+
+// RemActiveBenchRun clears the currently running benchmark run, if any.
+func (c *Controller) RemActiveBenchRun(ctx context.Context, benchID string) error {
+	exists, err := c.Redis.BenchmarkExists(ctx, benchID)
+	if err != nil {
+		return fmt.Errorf("%w: checking if benchmark is present failed: %w", types.ErrInternal, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("%w: benchmark does not exist", types.ErrNotFound)
+	}
+
+	if err := c.Redis.RemActiveBenchRun(ctx, benchID); err != nil {
+		return fmt.Errorf("%w: could not remove active benchmark run: %w", types.ErrInternal, err)
+	}
+
+	return nil
+}
+
 // Benchmarks pulls all known benchmark ids.
 func (c *Controller) Benchmarks(ctx context.Context) ([]string, error) {
 	benchs, err := c.Redis.Benchmarks(ctx)

--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -342,6 +342,101 @@ func TestRecordRuns(t *testing.T) {
 	})
 }
 
+func TestActiveBenchRun(t *testing.T) {
+	t.Parallel()
+
+	controller := controllers.Controller{Redis: store.RedisStore{Client: *client}, S3: objectStore}
+
+	bench := types.Bench{ //nolint: exhaustruct
+		Name:        "active-bench-run-bench",
+		Registries:  []string{"dummy-registry"},
+		Metrics:     []types.BenchMetric{{Name: "mae"}},
+		DatasetName: "dummy-dataset",
+		DatasetURL:  "https://example.com/dataset.zip",
+		Timestamp:   time.Now(),
+	}
+
+	benchID, created, err := controller.CreateBenchmark(t.Context(), bench)
+	require.NoError(t, err)
+	assert.True(t, created)
+
+	t.Run("setting_an_active_run_makes_it_visible_on_the_benchmark", func(t *testing.T) {
+		run := types.BenchRun{
+			Registry: "dummy-registry", Version: 1,
+			Metrics: map[string]float32{"mae": 92.0}, Timestamp: time.Now(),
+			Start: time.Now(), End: time.Time{},
+		}
+
+		err := controller.SetActiveBenchRun(t.Context(), benchID, run)
+		require.NoError(t, err)
+
+		got, err := controller.Benchmark(t.Context(), benchID)
+		require.NoError(t, err)
+		assert.Equal(t, run.Registry, got.ActiveBenchRun.Registry)
+		assert.Equal(t, run.Version, got.ActiveBenchRun.Version)
+	})
+
+	t.Run("setting_a_new_active_run_replaces_the_previous_one", func(t *testing.T) {
+		err := controller.SetActiveBenchRun(t.Context(), benchID, types.BenchRun{ //nolint: exhaustruct
+			Registry: "dummy-registry", Version: 1,
+		})
+		require.NoError(t, err)
+
+		err = controller.SetActiveBenchRun(t.Context(), benchID, types.BenchRun{ //nolint: exhaustruct
+			Registry: "dummy-registry", Version: 2,
+		})
+		require.NoError(t, err)
+
+		got, err := controller.Benchmark(t.Context(), benchID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), got.ActiveBenchRun.Version)
+	})
+
+	t.Run("removing_the_active_run_clears_it_from_the_benchmark", func(t *testing.T) {
+		err := controller.SetActiveBenchRun(t.Context(), benchID, types.BenchRun{ //nolint: exhaustruct
+			Registry: "dummy-registry", Version: 3,
+		})
+		require.NoError(t, err)
+
+		err = controller.RemActiveBenchRun(t.Context(), benchID)
+		require.NoError(t, err)
+
+		got, err := controller.Benchmark(t.Context(), benchID)
+		require.NoError(t, err)
+		assert.Zero(t, got.ActiveBenchRun)
+	})
+
+	t.Run("removing_an_active_run_that_was_never_set_is_a_no-op", func(t *testing.T) {
+		noRunBenchID, created, err := controller.CreateBenchmark(t.Context(), types.Bench{ //nolint: exhaustruct
+			Name:        "no-active-run-bench",
+			Registries:  []string{"dummy-registry"},
+			Metrics:     []types.BenchMetric{{Name: "mae"}},
+			DatasetName: "dummy-dataset",
+			DatasetURL:  "https://example.com/dataset.zip",
+			Timestamp:   time.Now(),
+		})
+		require.NoError(t, err)
+		require.True(t, created)
+
+		err = controller.RemActiveBenchRun(t.Context(), noRunBenchID)
+		require.NoError(t, err)
+	})
+
+	t.Run("setting_an_active_run_for_an_unknown_benchmark_returns_not_found", func(t *testing.T) {
+		err := controller.SetActiveBenchRun(t.Context(), "unknown-benchmark-id", types.BenchRun{ //nolint: exhaustruct
+			Registry: "dummy-registry", Version: 1,
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, types.ErrNotFound))
+	})
+
+	t.Run("removing_an_active_run_for_an_unknown_benchmark_returns_not_found", func(t *testing.T) {
+		err := controller.RemActiveBenchRun(t.Context(), "unknown-benchmark-id")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, types.ErrNotFound))
+	})
+}
+
 func TestExpInfo(t *testing.T) {
 	t.Run("add_description_to_exp", func(t *testing.T) {
 		t.Parallel()

--- a/solid/controllers/controller_test.go
+++ b/solid/controllers/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -374,6 +375,14 @@ func TestActiveBenchRun(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, run.Registry, got.ActiveBenchRun.Registry)
 		assert.Equal(t, run.Version, got.ActiveBenchRun.Version)
+
+		// A self-expiring TTL bounds how long a stuck active run can survive
+		// a RemActiveBenchRun that never succeeds (crash, sustained outage).
+		ttl, err := client.HExpireTime(t.Context(),
+			fmt.Sprintf(store.BenchmarkKeyPattern, benchID), "ActiveBenchRun").Result()
+		require.NoError(t, err)
+		require.Len(t, ttl, 1)
+		assert.Greater(t, ttl[0], time.Now().Add(4*24*time.Hour).Unix())
 	})
 
 	t.Run("setting_a_new_active_run_replaces_the_previous_one", func(t *testing.T) {

--- a/solid/store/benchmark.go
+++ b/solid/store/benchmark.go
@@ -339,7 +339,13 @@ func (r *RedisStore) BenchmarkRuns(ctx context.Context, benchID string) ([]*type
 	return runs, nil
 }
 
-// SetActiveBenchRun sets the active run of a benchmark.
+// SetActiveBenchRun records run as the benchmark run currently in progress
+// for benchID, so callers can tell which run is executing before it
+// finishes and is written via RecordRuns. It is stored in the
+// "ActiveBenchRun" field of the benchmark's hash as a JSON blob and
+// overwrites whatever active run was previously set, so only one run is
+// ever considered active per benchmark. Callers are responsible for
+// clearing it with RemActiveBenchRun once the run completes.
 func (r *RedisStore) SetActiveBenchRun(ctx context.Context, benchID string, run types.BenchRun) error {
 	key := r.makeBenchmarkKey(benchID)
 
@@ -357,7 +363,9 @@ func (r *RedisStore) SetActiveBenchRun(ctx context.Context, benchID string, run 
 	return nil
 }
 
-// RemActiveBenchRun removes the active run of a benchmark.
+// RemActiveBenchRun clears the "ActiveBenchRun" field set by
+// SetActiveBenchRun, e.g. once a run has finished and been recorded. It is
+// a no-op, not an error, when no active run is set.
 func (r *RedisStore) RemActiveBenchRun(ctx context.Context, benchID string) error {
 	_, err := r.Client.HDel(ctx, r.makeBenchmarkKey(benchID), "ActiveBenchRun").Result()
 	if err != nil {
@@ -530,6 +538,8 @@ func parseBenchmark(benchID string, data, metrics *redis.MapStringStringCmd,
 
 	var benchRun types.BenchRun
 
+	// "ActiveBenchRun" is absent for the common case of a benchmark with no
+	// run in progress, so only attempt to parse it when present.
 	if run, ok := mapping["ActiveBenchRun"]; ok && run != "" {
 		err = json.Unmarshal([]byte(mapping["ActiveBenchRun"]), &benchRun)
 		if err != nil {

--- a/solid/store/benchmark.go
+++ b/solid/store/benchmark.go
@@ -12,6 +12,13 @@ import (
 	"github.com/zeddo123/mlsolid/solid/types"
 )
 
+// activeBenchRunTTL bounds how long an "ActiveBenchRun" field can survive
+// without being refreshed, so a run that never gets cleared (crashed
+// process, RemActiveBenchRun failing to reach Redis) self-heals instead of
+// showing as active forever. Set well above any expected benchmark run
+// duration.
+const activeBenchRunTTL = 5 * 24 * time.Hour
+
 // CreateBenchmark creates a new benchmark.
 func (r *RedisStore) CreateBenchmark(ctx context.Context, b types.Bench) (bool, error) {
 	benchKey := r.makeBenchmarkKey(b.ID)
@@ -357,6 +364,12 @@ func (r *RedisStore) SetActiveBenchRun(ctx context.Context, benchID string, run 
 	_, err = r.Client.HSet(ctx, key, "ActiveBenchRun", content).Result()
 	if err != nil {
 		return fmt.Errorf("%w: could not set active benchmark field of benchmark %q due to %w",
+			types.ErrInternal, benchID, err)
+	}
+
+	_, err = r.Client.HExpire(ctx, key, activeBenchRunTTL, "ActiveBenchRun").Result()
+	if err != nil {
+		return fmt.Errorf("%w: could not set expiry on active benchmark field of benchmark %q due to %w",
 			types.ErrInternal, benchID, err)
 	}
 

--- a/solid/store/benchmark.go
+++ b/solid/store/benchmark.go
@@ -339,6 +339,34 @@ func (r *RedisStore) BenchmarkRuns(ctx context.Context, benchID string) ([]*type
 	return runs, nil
 }
 
+// SetActiveBenchRun sets the active run of a benchmark.
+func (r *RedisStore) SetActiveBenchRun(ctx context.Context, benchID string, run types.BenchRun) error {
+	key := r.makeBenchmarkKey(benchID)
+
+	content, err := json.Marshal(run)
+	if err != nil {
+		return fmt.Errorf("%w: could not marshal benchmark run due to %w", types.ErrInternal, err)
+	}
+
+	_, err = r.Client.HSet(ctx, key, "ActiveBenchRun", content).Result()
+	if err != nil {
+		return fmt.Errorf("%w: could not set active benchmark field of benchmark %q due to %w",
+			types.ErrInternal, benchID, err)
+	}
+
+	return nil
+}
+
+// RemActiveBenchRun removes the active run of a benchmark.
+func (r *RedisStore) RemActiveBenchRun(ctx context.Context, benchID string) error {
+	_, err := r.Client.HDel(ctx, r.makeBenchmarkKey(benchID), "ActiveBenchRun").Result()
+	if err != nil {
+		return fmt.Errorf("%w: could not delete active benchmark run field due to %w", types.ErrInternal, err)
+	}
+
+	return nil
+}
+
 // Benchmarks returns all known benchmarks.
 func (r *RedisStore) Benchmarks(ctx context.Context) ([]string, error) {
 	benchs, err := r.zIndexAll(ctx, BenchmarksKey)
@@ -500,6 +528,15 @@ func parseBenchmark(benchID string, data, metrics *redis.MapStringStringCmd,
 		return nil, fmt.Errorf("could not parse benchmark metrics: %w", err)
 	}
 
+	var benchRun types.BenchRun
+
+	if run, ok := mapping["ActiveBenchRun"]; ok && run != "" {
+		err = json.Unmarshal([]byte(mapping["ActiveBenchRun"]), &benchRun)
+		if err != nil {
+			log.Printf("could not parse active benchmark run Run=%s err=%s\n", mapping["ActiveBenchRun"], err)
+		}
+	}
+
 	return &types.Bench{
 		ID:             benchID,
 		Name:           mapping["Name"],
@@ -514,6 +551,7 @@ func parseBenchmark(benchID string, data, metrics *redis.MapStringStringCmd,
 		Timestamp:      timestamp,
 		Registries:     regs,
 		Metrics:        mets,
+		ActiveBenchRun: benchRun,
 	}, nil
 }
 

--- a/solid/types/benchmark.go
+++ b/solid/types/benchmark.go
@@ -24,6 +24,7 @@ type Bench struct {
 	DatasetURL     string        `json:"datasetUrl"     validate:"required,url"`
 	FromS3         bool          `json:"fromS3"`
 	Timestamp      time.Time     `json:"timestamp"      validate:"required"`
+	ActiveBenchRun BenchRun      `json:"activeBenchRun"`
 }
 
 // BenchMetric represents a benchmark metric.

--- a/solid/types/benchmark.go
+++ b/solid/types/benchmark.go
@@ -24,7 +24,12 @@ type Bench struct {
 	DatasetURL     string        `json:"datasetUrl"     validate:"required,url"`
 	FromS3         bool          `json:"fromS3"`
 	Timestamp      time.Time     `json:"timestamp"      validate:"required"`
-	ActiveBenchRun BenchRun      `json:"activeBenchRun"`
+	// ActiveBenchRun is the run currently in flight for this benchmark, if
+	// any. It is distinct from the runs returned by BenchmarkRuns: it tracks
+	// a run that has started but not yet been recorded, and is the zero
+	// value (BenchRun{}) once no run is active. See
+	// RedisStore.SetActiveBenchRun and RedisStore.RemActiveBenchRun.
+	ActiveBenchRun BenchRun `json:"activeBenchRun"`
 }
 
 // BenchMetric represents a benchmark metric.


### PR DESCRIPTION
This commit provides store methods to set/del a new active benchmark run field used to check which run is currently running on the bEngine.