### PR TITLE
feat: create benchmark in populate script

### DIFF
--- a/cmd/populate/benchmark.go
+++ b/cmd/populate/benchmark.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"buf.build/gen/go/zeddo123/mlsolid/grpc/go/mlsolid/v1/mlsolidv1grpc"
+	mlsolidv1 "buf.build/gen/go/zeddo123/mlsolid/protocolbuffers/go/mlsolid/v1"
+	"github.com/anandvarma/namegen"
+)
+
+// DummyImage's entrypoint sleeps for 20s and always writes a fixed set of
+// metrics to its output file, see bench-container-example/entrypoint.py.
+const DummyImage = "ghcr.io/zeddo123/bench-dummy:0.0.4"
+
+const (
+	benchmarkDatasetName = "chinese-mnist"
+	benchmarkDatasetURL  = "https://www.kaggle.com/api/v1/datasets/download/gpreda/chinese-mnist"
+)
+
+// createBenchmark creates a benchmark watching registryName and points the
+// registry's docker image at DummyImage. Once wired up this way, every
+// subsequent model entry added to registryName (e.g. via createRun's
+// AddModelEntry call) makes the server publish a real bEngine event that
+// pulls and runs the dummy benchmark container.
+func createBenchmark(client mlsolidv1grpc.MlsolidServiceClient, registryName string) string {
+	image := DummyImage
+
+	_, err := client.SetRegistryBenchmarkOps(context.Background(), &mlsolidv1.SetRegistryBenchmarkOpsRequest{
+		Name:           registryName,
+		BenchmarkImage: &image,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("[populate]: set benchmark image registry=%s image=%s \n", registryName, image)
+
+	resp, err := client.CreateBenchmark(context.Background(), &mlsolidv1.CreateBenchmarkRequest{ //nolint: exhaustruct
+		Name:            namegen.New().Get(),
+		ModelRegistries: []string{registryName},
+		Metrics: []*mlsolidv1.BenchmarkMetric{
+			{Name: "mae"},  //nolint: exhaustruct
+			{Name: "loss"}, //nolint: exhaustruct
+		},
+		DecisionMetric: "loss",
+		DatasetName:    benchmarkDatasetName,
+		DatasetUrl:     benchmarkDatasetURL,
+		AutoTag:        true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("[populate]: benchmark created benchId=%s registry=%s \n", resp.GetBenchmarkId(), registryName)
+
+	return resp.GetBenchmarkId()
+}

--- a/cmd/populate/populate_server.go
+++ b/cmd/populate/populate_server.go
@@ -47,6 +47,7 @@ func main() {
 			log.Println("[populate] getting experiments... ", resp.GetExpIds())
 
 			createModelRegistry(client, "Yolo Prod") //nolint: contextcheck
+			createBenchmark(client, "Yolo Prod")     //nolint: contextcheck
 
 			maxExps := 3
 			maxRuns := 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:7.4.7-bookworm
+    image: redis:8.2.7-bookworm
 
   mlsolid:
     image: mlsolid

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 			bengine.WithS3(objectStore),
 			bengine.WithHostSourceVolume(config.HostSourceVolume),
 			bengine.WithRegistryCreds(config.DockerRegistryUsername, config.DockerRegistryPassword),
+			bengine.WithRootDest(config.BEngineRootDest),
 		)
 
 		go engine.Start(context.Background())

--- a/solid/bengine/engine.go
+++ b/solid/bengine/engine.go
@@ -171,12 +171,16 @@ func (e *Engine) Start(ctx context.Context) {
 	for {
 		select {
 		case msg, ok := <-e.sub.Msgs:
+			e.l.Info().Msg("got message event")
+
 			if !ok {
 				return
 			}
 
-			event, ok := msg.(*types.BenchEvent)
+			event, ok := msg.(types.BenchEvent)
 			if !ok {
+				e.l.Error().Any("event", msg).Msg("could not cast msg event to types.BenchEvent")
+
 				break
 			}
 
@@ -193,7 +197,7 @@ func (e *Engine) Start(ctx context.Context) {
 				Str("tag", event.Tag).
 				Msg("received benchmark event")
 
-			e.handleEvent(ctx, event)
+			e.handleEvent(ctx, &event)
 
 		case <-ctx.Done():
 			e.l.Info().Msg("shutting down bEngine")
@@ -323,7 +327,7 @@ func (e *Engine) RunContainer(
 		Msg("starting container")
 
 	source := e.rootDest
-	target := e.rootDest
+	target := "/mlsolid"
 
 	if e.hostSourceVolume != "" {
 		source = e.hostSourceVolume
@@ -334,8 +338,8 @@ func (e *Engine) RunContainer(
 		ctr.WithImage(image),
 		ctr.WithCmd([]string{
 			"-dn", datasetName,
-			"-d", datasetPath,
-			"-m", checkpointPath,
+			"-d", filepath.Join(target, "datasets", datasetName),
+			"-m", filepath.Join(target, "checkpoints", "model.pth"),
 			"-o", outputPath,
 		}...),
 		ctr.WithHostConfigModifier(func(hostConfig *container.HostConfig) {

--- a/solid/bengine/engine_test.go
+++ b/solid/bengine/engine_test.go
@@ -65,7 +65,7 @@ func TestEngineRun(t *testing.T) {
 
 	require.NotNil(t, e)
 
-	event := &types.BenchEvent{ //nolint: exhaustruct
+	event := types.BenchEvent{ //nolint: exhaustruct
 		BenchID:     benchID,
 		Registry:    "dummy-registry",
 		Version:     1,

--- a/solid/config.go
+++ b/solid/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	S3Prefix   string `mapstructure:"s3_prefix"`
 
 	EnableBEngine          bool   `mapstructure:"enable_bengine"`
+	BEngineRootDest        string `mapstructure:"bengine_root_dest"`
 	DockerRegistryUsername string `mapstructure:"docker_registry_username"`
 	DockerRegistryPassword string `mapstructure:"docker_registry_password"`
 	HostSourceVolume       string `mapstructure:"host_source_volume"`
@@ -76,6 +77,7 @@ func LoadConfig(path string) (Config, error) {
 	viper.SetDefault("s3_prefix", "artifacts")
 
 	viper.SetDefault("enable_bengine", false)
+	viper.SetDefault("bengine_root_dest", "/mlsolid/")
 	viper.SetDefault("docker_registry_username", "")
 	viper.SetDefault("docker_registry_password", "")
 	viper.SetDefault("host_source_volume", "")

--- a/solid/controllers/controller.go
+++ b/solid/controllers/controller.go
@@ -20,6 +20,8 @@ type Controller struct {
 }
 
 func (c *Controller) pushBengineEvent(ctx context.Context, registryName string, version int) {
+	c.Logger.Info().Str("registry", registryName).Int("version", version).Msg("pushing Bengine event")
+
 	registry, err := c.Redis.ModelRegistry(ctx, registryName)
 	if err != nil {
 		c.Logger.Error().Err(err).Msg("could not pull registry from db")
@@ -53,6 +55,7 @@ func (c *Controller) pushBengineEvent(ctx context.Context, registryName string, 
 			Str("registry", registryName).
 			Int("version", version).
 			Str("benchID", bench.ID).
+			Str("container-image", registry.BenchmarkImage).
 			Msg("publishing benchmark event")
 
 		err = c.Bus.Publish("bengine", types.BenchEvent{

--- a/solid/controllers/models.go
+++ b/solid/controllers/models.go
@@ -35,6 +35,8 @@ func (c *Controller) CreateModelRegistry(ctx context.Context,
 
 // LastModelEntry returns the last model entry in the model registry.
 func (c *Controller) LastModelEntry(ctx context.Context, registryName string) (types.ModelEntry, error) {
+	registryName = types.SanitizeName(registryName)
+
 	entry, err := c.Redis.LastModel(ctx, registryName)
 	if err != nil {
 		return types.ModelEntry{}, fmt.Errorf("failed getting last model of %q: %w", registryName, err)
@@ -45,6 +47,8 @@ func (c *Controller) LastModelEntry(ctx context.Context, registryName string) (t
 
 // TaggedModel returns the latest model entry with the specified tag.
 func (c *Controller) TaggedModel(ctx context.Context, registryName string, tag string) (types.ModelEntry, error) {
+	registryName = types.SanitizeName(registryName)
+
 	entry, err := c.Redis.ModelByTag(ctx, registryName, tag)
 	if err != nil {
 		return types.ModelEntry{}, fmt.Errorf("failed getting latest enty with %q model from %q: %w", tag, registryName, err)
@@ -68,7 +72,7 @@ func (c *Controller) AddModelEntry(ctx context.Context, registryName string, url
 	}
 
 	if c.PublishBenchEvents {
-		go c.pushBengineEvent(ctx, registryName, registry.LatestVersion())
+		go c.pushBengineEvent(context.Background(), registryName, registry.LatestVersion())
 	}
 
 	return nil
@@ -96,7 +100,7 @@ func (c *Controller) AddArtifactToRegistry(ctx context.Context, registryName str
 	}
 
 	if c.PublishBenchEvents {
-		go c.pushBengineEvent(ctx, registryName, registry.LatestVersion())
+		go c.pushBengineEvent(context.Background(), registryName, registry.LatestVersion())
 	}
 
 	return nil
@@ -147,7 +151,7 @@ func (c *Controller) ModelRegistriesIDPage(ctx context.Context, cursor uint64, l
 
 // UpdateRegistryDockerImage updates the docker image of a registry.
 func (c *Controller) UpdateRegistryDockerImage(ctx context.Context, registry, dockerImage string) error {
-	err := c.Redis.UpdateRegistryDockerImage(ctx, registry, dockerImage)
+	err := c.Redis.UpdateRegistryDockerImage(ctx, types.SanitizeName(registry), dockerImage)
 	if err != nil {
 		return fmt.Errorf("update failed: %w", err)
 	}
@@ -156,7 +160,7 @@ func (c *Controller) UpdateRegistryDockerImage(ctx context.Context, registry, do
 }
 
 func (c *Controller) UpdateRegistryBenchmarkGpuPassthrough(ctx context.Context, registry string, pass bool) error {
-	err := c.Redis.UpdateRegistryBenchmarkGpuPassthrough(ctx, registry, pass)
+	err := c.Redis.UpdateRegistryBenchmarkGpuPassthrough(ctx, types.SanitizeName(registry), pass)
 	if err != nil {
 		return fmt.Errorf("update failed: %w", err)
 	}

--- a/solid/types/benchmark.go
+++ b/solid/types/benchmark.go
@@ -100,6 +100,11 @@ func (b *Bench) Validate() error {
 func (b *Bench) Sanitize() {
 	b.Name = SanitizeName(b.Name)
 	b.DatasetName = strings.TrimSpace(b.DatasetName)
+	b.Registries = SanitizeNames(b.Registries)
+
+	for i, m := range b.Metrics {
+		b.Metrics[i].Name = SanitizeName(m.Name)
+	}
 }
 
 // BenchMetrics returns the names of metrics tracked.


### PR DESCRIPTION
This commit creates a new benchmark with random name in `cmd/populate`; This should trigger a bEngine event, run a dummy container and record the run in redis.